### PR TITLE
Refactor codebase to silence all compiler warnings

### DIFF
--- a/include/MersenneTwister.h
+++ b/include/MersenneTwister.h
@@ -219,7 +219,7 @@ inline MTRand::uint32 MTRand::randInt()
     if( left == 0 ) reload();
     --left;
 
-    register uint32 s1;
+    uint32 s1;
     s1 = *pNext++;
     s1 ^= (s1 >> 11);
     s1 ^= (s1 <<  7) & 0x9d2c5680UL;
@@ -264,9 +264,9 @@ inline void MTRand::seed( uint32 *const bigSeed, const uint32 seedLength )
     // in each element are discarded.
     // Just call seed() if you want to get array from /dev/urandom
     initialize(19650218UL);
-    register int i = 1;
-    register uint32 j = 0;
-    register int k = ( N > seedLength ? N : seedLength );
+    int i = 1;
+    uint32 j = 0;
+    int k = ( N > seedLength ? N : seedLength );
     for( ; k; --k )
     {
         state[i] =
@@ -310,9 +310,9 @@ inline void MTRand::seed()
     if( urandom )
     {
         uint32 bigSeed[N];
-        register uint32 *s = bigSeed;
-        register int i = N;
-        register bool success = true;
+        uint32 *s = bigSeed;
+        int i = N;
+        bool success = true;
         while( success && i-- )
             success = fread( s++, sizeof(uint32), 1, urandom );
         fclose(urandom);
@@ -334,9 +334,9 @@ inline void MTRand::initialize( const uint32 seed )
     // See Knuth TAOCP Vol 2, 3rd Ed, p.106 for multiplier.
     // In previous versions, most significant bits (MSBs) of the seed affect
     // only MSBs of the state array.  Modified 9 Jan 2002 by Makoto Matsumoto.
-    register uint32 *s = state;
-    register uint32 *r = state;
-    register int i = 1;
+    uint32 *s = state;
+    uint32 *r = state;
+    int i = 1;
     *s++ = seed & 0xffffffffUL;
     for( ; i < N; ++i )
     {
@@ -350,8 +350,8 @@ inline void MTRand::reload()
 {
     // Generate N new values in state
     // Made clearer and faster by Matthew Bellew (matthew.bellew@home.com)
-    register uint32 *p = state;
-    register int i;
+    uint32 *p = state;
+    int i;
     for( i = N - M; i--; ++p )
         *p = twist( p[M], p[0], p[1] );
     for( i = M; --i; ++p )
@@ -390,9 +390,9 @@ inline MTRand::uint32 MTRand::hash( time_t t, clock_t c )
 
 inline void MTRand::save( uint32* saveArray ) const
 {
-    register uint32 *sa = saveArray;
-    register const uint32 *s = state;
-    register int i = N;
+    uint32 *sa = saveArray;
+    const uint32 *s = state;
+    int i = N;
     for( ; i--; *sa++ = *s++ ) {}
     *sa = left;
 }
@@ -400,9 +400,9 @@ inline void MTRand::save( uint32* saveArray ) const
 
 inline void MTRand::load( uint32 *const loadArray )
 {
-    register uint32 *s = state;
-    register uint32 *la = loadArray;
-    register int i = N;
+    uint32 *s = state;
+    uint32 *la = loadArray;
+    int i = N;
     for( ; i--; *s++ = *la++ ) {}
     left = *la;
     pNext = &state[N-left];
@@ -411,8 +411,8 @@ inline void MTRand::load( uint32 *const loadArray )
 
 inline std::ostream& operator<<( std::ostream& os, const MTRand& mtrand )
 {
-    register const MTRand::uint32 *s = mtrand.state;
-    register int i = mtrand.N;
+    const MTRand::uint32 *s = mtrand.state;
+    int i = mtrand.N;
     for( ; i--; os << *s++ << "\t" ) {}
     return os << mtrand.left;
 }
@@ -420,8 +420,8 @@ inline std::ostream& operator<<( std::ostream& os, const MTRand& mtrand )
 
 inline std::istream& operator>>( std::istream& is, MTRand& mtrand )
 {
-    register MTRand::uint32 *s = mtrand.state;
-    register int i = mtrand.N;
+    MTRand::uint32 *s = mtrand.state;
+    int i = mtrand.N;
     for( ; i--; is >> *s++ ) {}
     is >> mtrand.left;
     mtrand.pNext = &mtrand.state[mtrand.N-mtrand.left];

--- a/include/corticalSimReal.h
+++ b/include/corticalSimReal.h
@@ -1122,6 +1122,3 @@ class Triangle : public Cartesian
 
 #endif
 //CORTICALSIM_H_
-
-
-

--- a/include/corticalSimReal.h
+++ b/include/corticalSimReal.h
@@ -170,9 +170,9 @@ class TrajectoryVector
 {
     public:
 
-    Trajectory* trajectory;
     double pos;
     Direction dir,Cdir;
+    Trajectory* trajectory;
 
     TrajectoryVector(double p, Direction d, Trajectory* t) : pos(p), dir(d), trajectory(t) {}
     TrajectoryVector() {}
@@ -451,6 +451,9 @@ class Region
 
     //const RegionType type;
     double area;
+    double totalLength;
+    // time tag at which the length was last updated
+    int previousUpdateTag;
     int regionId;
     double zOffset;
     double rotAngle;
@@ -475,10 +478,7 @@ class Region
     list<MTTip*> minusTipList;
     RegionMTTipTag registerOnRegion(MTTip*,TipType,MTType);
     void unregisterFromRegion(RegionMTTipTag,TipType,MTType);
-    double totalLength;
 
-    // time tag at which the length was last updated
-    int previousUpdateTag;
 
     // updates the length to the current system time tag
     void updateRegionLength(bool forceUpdate = false);
@@ -602,15 +602,6 @@ class Geometry
 class DeterministicQueue
 //'Smart' queue object that contains logic to transform to and from the system time.
 {
-    //public:
-    friend class System;
-    priority_queue<DeterministicEvent> queue;	// the queue itself
-    double currentBase;							// the current 'distance'
-    double valueCache[POSITION_CACHE_SIZE];		// cache of previous 'distance' values
-    double (System::* const distanceTimeConversionFunction)(double);
-    // pointer to a function that converts a distance to a time
-    double (System::* const timeDistanceConversionFunction)(double);
-    // pointer to a function that converts a time to a distance
 
     public:
     System* const 	system;						// pointer to containing system
@@ -636,6 +627,16 @@ class DeterministicQueue
     void pushGlobal(double, GlobalEventType);	// pushes a global event onto the queue at a certain distance
     EventTrackingTag pushDeterministic(double, EventDescriptorIndex);
     // pushes a deterministic (MT) event onto the queue at a certain distance
+
+    private:
+    friend class System;
+    priority_queue<DeterministicEvent> queue; // the queue itself
+    double currentBase;                       // the current 'distance'
+    double valueCache[POSITION_CACHE_SIZE]; // cache of previous 'distance' values
+    double (System::* const distanceTimeConversionFunction) (double);
+    // pointer to a function that converts a distance to a time
+    double (System::* const timeDistanceConversionFunction) (double);
+    // pointer to a function that converts a time to a distance
 };
 
 class EventDescriptor
@@ -701,13 +702,13 @@ class MTTip
     Microtubule* mt;
     Trajectory* trajectory;
 
+    Direction dir;
+    double velocity;
+    EventDescriptor event;
+    IntersectionItr	nextCollision;
     TrjMTTipTag notificationTag;
     RegionMTTipTag regionTag;
-    double velocity;
-    Direction dir;
-    IntersectionItr	nextCollision;
     double nextEventPos;
-    EventDescriptor event;
     MTTip(Microtubule*, TrajectoryVector, double, DeterministicQueue*, double);
     ~MTTip();
     TipType type();
@@ -762,19 +763,19 @@ class Microtubule : public DLBaseItem<Microtubule>
 {
     public:
     System* const system;
+    MTTip plus;
+    MTTip minus;
+
+    // event descriptor for events that are not directly associated to a single tip (only disappearance)
+    EventDescriptor disappearEvent;
+    // type of microtubule (growing, shrinking)
+    MTType type;
     double nucleationTime;
 
     // time tag at which the positions and lengths were last updated
     int previousUpdateTag;
 
-    // type of microtubule (growing, shrinking)
-    MTType type;
-    MTTip plus;
-    MTTip minus;
     DLList<Segment>	segments;
-
-    // event descriptor for events that are not directly associated to a single tip (only disappearance)
-    EventDescriptor disappearEvent;
 
     Microtubule(System*, TrajectoryVector, bool = true);
     ~Microtubule();

--- a/include/meshImport.h
+++ b/include/meshImport.h
@@ -32,7 +32,7 @@ class Triangle3D
 
         Triangle3D()
         {
-            elementId = 0;   
+            elementId = 0;
 	    edgeTag = 0;
 	    faceTag = 1;
             polyIntersectMark = 0;
@@ -41,7 +41,7 @@ class Triangle3D
             area = 0.000001;
             periMeter = 0.000001;
 	    edgAngNorm = 0.000001;
-	    pcatEdgeWeight = 0.000001;           
+	    pcatEdgeWeight = 0.000001;
             midPoint << 0.0,0.0,0.0;
             givenNormal << 0.0,0.0,0.0;
 
@@ -110,6 +110,3 @@ bool linePlaneIntersect(Vector3d, Vector3d, Vector3d, Vector3d, Vector3d&);
 double areaPolygon3D(vector<Vertics>&,Vector3d);
 
 double intersectingPolygon(vector<Vertics>&,vector<Vertics>&,vector<Region*>&,vector<elementList> &,Vector3d,Vector3d,string);
-
-
-

--- a/src/IO-analysis.cpp
+++ b/src/IO-analysis.cpp
@@ -221,4 +221,3 @@ void System::writeMeasurementsToFile(int numberToKeep)
 
     return;
 }
-

--- a/src/IO-analysis.cpp
+++ b/src/IO-analysis.cpp
@@ -22,7 +22,6 @@ void writeMeasurementDescriptors(ostream& o)
 
 void System::initializeOutput(void)
 {
-    int j;
 
     // if create sub-directory in enabled
     if (p.createSubdir)
@@ -103,10 +102,6 @@ void System::closeFiles()
 void System::performMeasurement(void)
 {
     Measurement m;
-    double *h;
-    double *al;
-    int *an;
-    int i;
 
     // measurementHistory reach at MAX_HISTORY_SIZE, archive only upto last MIN_HISTORY_SIZE arrays, and write down the rest on output file (immediately !)
     if (measurementHistory.size() == MAX_HISTORY_SIZE)
@@ -189,16 +184,6 @@ void System::performMeasurement(void)
     m.occupiedIntersectionCount = 0;
     #endif
 
-    // value of plus end velocity
-    double realVplus;
-
-    // infinite tubulin pool
-    if (p.restrictedPool == 0)
-        realVplus = p.vPlus;
-    // finite tubulin pool
-    else
-        realVplus = p.vPlus*(1.0 - totalLength/(p.poolDensity*geometry->area));
-
     // G-effective at difference faces
     //for(int dTag =0;dTag <=p.faceNumber; dTag++)
     //m.G_effAdjust.push_back = (p.kRes/(-p.vMin+p.vTM) - p.RegionKcatMultiplier[dTag]*p.kCat/(realVplus - p.vTM))*pow((2.0*(-p.vMin+p.vTM)*(realVplus-p.vTM)*(realVplus - p.vTM))/
@@ -223,7 +208,7 @@ void System::performMeasurement(void)
 
 void System::writeMeasurementsToFile(int numberToKeep)
 {
-    int i,j, iMax;
+    int i, iMax;
 
     iMax = measurementHistory.size()-numberToKeep;
 

--- a/src/geometry-generic.cpp
+++ b/src/geometry-generic.cpp
@@ -138,14 +138,13 @@ SurfaceVector Geometry::randomSurfaceVector()
 
 bool Geometry::integrityCheck()
 {
-    int ridx(0);
     bool valid(true);
     int plusGrowCount(0);
     int plusShrinkCount(0);
     int minusCount(0);
     Trajectory* tptr(NULL);
 
-    for (ridx = 0; ridx < regions.size(); ridx++)
+    for (size_t ridx = 0; ridx < regions.size(); ridx++)
     {
         plusGrowCount += regions[ridx]->growingPlusTipList.size();
         plusShrinkCount += regions[ridx]->shrinkingPlusTipList.size();
@@ -196,11 +195,10 @@ bool Geometry::integrityCheck()
 
 double Geometry::opticalLength()
 {
-    int ridx(0);
     double sum(0.0);
 
     // calculate total optical length present in the geometry
-    for (ridx = 0; ridx < regions.size(); ridx++)
+    for (size_t ridx = 0; ridx < regions.size(); ridx++)
     {
         sum += regions[ridx]->opticalLength();
     }
@@ -209,11 +207,10 @@ double Geometry::opticalLength()
 
 int Geometry::trajectoryCount()
 {
-    int ridx(0);
     int sum(0);
 
     // calculate total number of trajectory present in the geometry
-    for (ridx = 0; ridx < regions.size(); ridx++)
+    for (size_t ridx = 0; ridx < regions.size(); ridx++)
     {
         sum += regions[ridx]->trajectories.size();
     }
@@ -457,9 +454,8 @@ bool Trajectory::integrityCheck()
     }
 
     IntersectionItr is(wallBegin());
-    int isCount(0);
 
-    for (isCount = 1; isCount < intersections.size(); isCount++)
+    for (size_t isCount = 1; isCount < intersections.size(); isCount++)
     {
         is++;
         if (is->second.mirror->second.mirror != is)

--- a/src/geometry-special.cpp
+++ b/src/geometry-special.cpp
@@ -3,7 +3,7 @@
 
 TriMeshGeometry::TriMeshGeometry(System* s):Geometry(s,0.0)
 {
-	// loading a triangle mesh 
+	// loading a triangle mesh
     	pickup_shape(this);
 
     	return;
@@ -34,9 +34,9 @@ void TriMeshGeometry::getOrderParameters(OrderParameters& op)
 		opRaw.Qzz /= opRaw.localL;
 	}
 
-    	/// calculate Q(2) tensor order parameter 
+    	/// calculate Q(2) tensor order parameter
     	op.R = opRaw.extractR(op.Rdirector,system->p.geometry);
-    
+
     	// normalize the order parameter director
         Vector3d Rvec(op.Rdirector[0],op.Rdirector[1],op.Rdirector[2]);
 	Rvec/= Rvec.norm();
@@ -52,10 +52,10 @@ void TriMeshGeometry::getOrderParameters(OrderParameters& op)
 
 void TriMeshGeometry::outputSnapshot(ostream& out)
 {
-    // output the simulation results 
+    // output the simulation results
     for(int eno = 0;eno< elementMax; eno++)
     regions[eno]->outputSnapshot(out);
-   
+
     out << endl;
 
     return;
@@ -67,20 +67,20 @@ void TriMeshGeometry::outputOrderHeatMap(ostream& out,vector<double>& localOrder
 	{
         	Vector3d seg3D;
 
-		// Incircle radius of the triangle 
+		// Incircle radius of the triangle
 		double svLength = (2.0*regions[eno]->area*regions[eno]->area)/regions[eno]->periMeter;
 
-        	// get the region 3D rotation axis 
+        	// get the region 3D rotation axis
 		Vector3d cross(regions[eno]->Q.x(),regions[eno]->Q.y(),regions[eno]->Q.z());
-     		double crossMagnitude = cross.norm();  
-  
+     		double crossMagnitude = cross.norm();
+
 		Quaternion<double> qr(0.0,0.0,0.0,0.0),QR(0.0,0.0,0.0,0.0);
 
 
                 // region (and hence all the sgments in this region) need 3D rotation + translation
 		if(crossMagnitude>0.0)
 		{
-                        // translate and rotate the start point of the segment 
+                        // translate and rotate the start point of the segment
 			QR.w()= 0;
 			QR.x() = -1.0*svLength*sv[eno](0,0)+regions[eno]->midPoint(0,0);
 			QR.y() = -1.0*svLength*sv[eno](1,0)+regions[eno]->midPoint(1,0);
@@ -105,15 +105,15 @@ void TriMeshGeometry::outputOrderHeatMap(ostream& out,vector<double>& localOrder
 			out << seg3D(0,0)<< "," <<seg3D(1,0)<< "," << seg3D(2,0) << ","<<regions[eno]->regionId<<"@";
 	 	}
 
-                // need no rotation of the region (and hence all the sgments in this region) 
+                // need no rotation of the region (and hence all the sgments in this region)
 		else
 		{
-                        // translate the start point of the segment 
+                        // translate the start point of the segment
 			seg3D << -1.0*svLength*sv[eno](0,0)+regions[eno]->midPoint(0,0),-1.0*svLength*sv[eno](1,0)+regions[eno]->midPoint(1,0),-1.0*svLength*sv[eno](2,0)+regions[eno]->zOffset;
 			seg3D+=objectCM;
 			out << seg3D(0,0) << "," <<seg3D(1,0)<< "," << seg3D(2,0) << ",";
 
-			//translate the end point of the segment 
+			//translate the end point of the segment
 			seg3D << svLength*sv[eno](0,0)+regions[eno]->midPoint(0,0),svLength*sv[eno](1,0)+regions[eno]->midPoint(1,0),-1.0*svLength*sv[eno](2,0)+regions[eno]->zOffset;
 			seg3D+=objectCM;
 			out << seg3D(0,0)<< "," <<seg3D(1,0)<< "," << seg3D(2,0) << ","<<regions[eno]->regionId<<"@";
@@ -139,7 +139,7 @@ TrajectoryVector TriMeshGeometry::extendTrajectory(Trajectory* oldtr, Direction 
         // get copy of old trajectory region index
     	int regionIndex(oldtr->base.region->regionId),regionIndexNeigh(0);
 
-        // forward direction: move to the end of the trajectory 
+        // forward direction: move to the end of the trajectory
     	if(dir == ::forward)
     	{
         	newBase.x = oldtr->endPoint[1].x;
@@ -149,7 +149,7 @@ TrajectoryVector TriMeshGeometry::extendTrajectory(Trajectory* oldtr, Direction 
                 double tDx = oldtr->endPoint[1].x-oldtr->endPoint[0].x;
     		double tDy = oldtr->endPoint[1].y-oldtr->endPoint[0].y;
     		tDirector << tDx/oldtr->length,tDy/oldtr->length;
- 
+
                 // get the neighbouring region index
         	regionIndexNeigh = oldtr->endPoint[1].nextElement;
     	}
@@ -176,7 +176,7 @@ TrajectoryVector TriMeshGeometry::extendTrajectory(Trajectory* oldtr, Direction 
 
     	// get the new region for the fresh trajectory (to be created)
     	newBase.region = regions[regionIndexNeigh];
-   	
+
     	double cosEdgeAngle(1.0),pCatReg(0.0);
         int s(oldtr->base.region->sideRevMap[regionIndexNeigh]);
 
@@ -188,7 +188,7 @@ TrajectoryVector TriMeshGeometry::extendTrajectory(Trajectory* oldtr, Direction 
 
         // assign pCatReg for this for this (encountered) triangle edge
 	pCatReg = oldtr->base.region->side[s].pCat;
-	
+
     	// final correction to newBase angle -> [0 ... 2*PI]
 	if(newBase.angle >= 2*PI)
 	newBase.angle -= 2*PI;
@@ -232,7 +232,7 @@ double Cartesian::intersectionAngle(Trajectory* t1, Trajectory* t2)
 }
 
 void Cartesian::getOrderParametersRawFlat(OrderParametersRaw& opR,vector<Vector3d>& orientation,double area)
-{		
+{
 	double sin2(0.0),cos2(0.0);
 	Vector3d sv(0.0,0.0,0.0);
     	double angle(0.0),length(0.0),localLength(0.);
@@ -240,7 +240,7 @@ void Cartesian::getOrderParametersRawFlat(OrderParametersRaw& opR,vector<Vector3
     	double u1(0.0),u2(0.0),u3(0.0),orderLocal(0.0);
 	MatrixXd QF(3,3),QC(3,3),e(3,3),O_l(2,2);
 
-        // get the rotation matrix 
+        // get the rotation matrix
 	e << 	orientation[0][0],orientation[1][0],orientation[2][0],
 		orientation[0][1],orientation[1][1],orientation[2][1],
 	        orientation[0][2],orientation[1][2],orientation[2][2];
@@ -289,7 +289,7 @@ void Cartesian::getOrderParametersRawFlat(OrderParametersRaw& opR,vector<Vector3
 		sin2 /= localLength;
         	cos2 /= localLength;
 
-		// local order 		
+		// local order
 		double matrix[3][3] = {{qxx,qxy,qxz},{qxy,qyy,qyz},{qxz,qyz,qzz}};
         	double evecMat[3][3];
         	double eVal[3];
@@ -315,19 +315,19 @@ void Cartesian::getOrderParametersRawFlat(OrderParametersRaw& opR,vector<Vector3
                       	qxy,qyy,qyz,
                       	qxz,qyz,qzz;
 
-                // make tensor transformation 
+                // make tensor transformation
                 QC = e*QF*e.transpose();
-	
+
     		// accumulate all the Q(2) tensors components from different regions
     		opR.Qxx += localLength*QC(0,0);
     		opR.Qxy += localLength*QC(0,1);
     		opR.Qxz += localLength*QC(0,2);
     		opR.Qyy += localLength*QC(1,1);
     		opR.Qyz += localLength*QC(1,2);
-    		opR.Qzz += localLength*QC(2,2);	
+    		opR.Qzz += localLength*QC(2,2);
 
 		// add up length of the segments from all the regions
-		opR.localL += localLength;	
+		opR.localL += localLength;
 	}
 
         opR.localOrder = orderLocal;
@@ -350,10 +350,10 @@ void Cartesian::outputSnapshotOffset(ostream& out,double xOffset,double yOffset)
 {
         Vector3d seg3D;
 
-        // get the region 3D rotation axis 
+        // get the region 3D rotation axis
 	Vector3d cross(Q.x(),Q.y(),Q.z());
-     	double crossMagnitude = cross.norm();  
-  
+     	double crossMagnitude = cross.norm();
+
 	Quaternion<double> qr(0.0,0.0,0.0,0.0),QR(0.0,0.0,0.0,0.0);
 
 	Trajectory* tr;
@@ -363,16 +363,16 @@ void Cartesian::outputSnapshotOffset(ostream& out,double xOffset,double yOffset)
 	tr = trajectories.first();
 
 	while(tr != NULL)
-	{	
+	{
 		svec = tr->base;
 
-                // record segments in the snapshots	
+                // record segments in the snapshots
 		seg = tr->segments.begin();
 		while (seg != tr->segments.end())
 		{
 			svec = tr->base;
 
-                        // move to the starting end of the segment 
+                        // move to the starting end of the segment
 			translateVector(svec, (**seg).start);
 
 			// for backward direction retrieve actual base angle (during nucleation)
@@ -386,7 +386,7 @@ void Cartesian::outputSnapshotOffset(ostream& out,double xOffset,double yOffset)
                         // region (and hence all the sgments in this region) need 3D rotation + translation
      			if(crossMagnitude>0.0)
      			{
-                                // translate and rotate the start point of the segment 
+                                // translate and rotate the start point of the segment
         			QR.w()= 0;
 				QR.x() = svec.x+midPoint(0,0);
 				QR.y() = svec.y+midPoint(1,0);
@@ -411,15 +411,15 @@ void Cartesian::outputSnapshotOffset(ostream& out,double xOffset,double yOffset)
 				out << seg3D(0,0)<< "," <<seg3D(1,0)<< "," << seg3D(2,0) << ","<<regionId<<"@";
     		 	}
 
-                        // need no rotation of the region (and hence all the sgments in this region) 
+                        // need no rotation of the region (and hence all the sgments in this region)
    			else
     			{
-                                // translate the start point of the segment 
+                                // translate the start point of the segment
 				seg3D << svec.x+midPoint(0,0),svec.y+midPoint(1,0),zOffset;
 				seg3D+=geometry->objectCM;
 				out << seg3D(0,0) << "," <<seg3D(1,0)<< "," << seg3D(2,0) << ",";
-	
-				//translate the end point of the segment 
+
+				//translate the end point of the segment
         			seg3D << svec.x+midPoint(0,0)+(**seg).length()*cos(svec.angle),svec.y+midPoint(1,0)+(**seg).length()*sin(svec.angle),zOffset;
 				seg3D+=geometry->objectCM;
 				out << seg3D(0,0)<< "," <<seg3D(1,0)<< "," << seg3D(2,0) << ","<<regionId<<"@";
@@ -429,7 +429,7 @@ void Cartesian::outputSnapshotOffset(ostream& out,double xOffset,double yOffset)
 
 		tr = tr->next();
 	}
-	
+
 	return;
 }
 
@@ -529,7 +529,7 @@ void Cartesian::makeIntersectionList(Trajectory* tr1)
 
 Triangle::Triangle(double elementArea, Geometry* g):Cartesian(g,elementArea)
 {
-        // necessary to create a full geometry, made with many triangles 
+        // necessary to create a full geometry, made with many triangles
 	return;
 }
 
@@ -538,7 +538,7 @@ SurfaceVector Triangle::randomSurfaceVector()
 	SurfaceVector v;
 	double r1(0.0),r2(0.0);
 
-        // get system pointer 
+        // get system pointer
     	System* s(geometry->system);
 
         // random number between (0,1)
@@ -551,7 +551,7 @@ SurfaceVector Triangle::randomSurfaceVector()
     	// generate uniformly and isotropically distributed nucleation points on each triangle
     	v.x = (1 - sqr1) * Vertics[0](0,0) + (sqr1 * (1 - r2)) * Vertics[1](0,0) + (sqr1 * r2) * Vertics[2](0,0);
     	v.y = (1 - sqr1) * Vertics[0](1,0) + (sqr1 * (1 - r2)) * Vertics[1](1,0) + (sqr1 * r2) * Vertics[2](1,0);
-        
+
         // make the unifor distribution also isotropic
     	v.angle = s->randomGen.randExc(2*PI);
 
@@ -581,7 +581,7 @@ void Triangle::getTrajectoryCoordinates(SurfaceVector& sVec,double& totalLength,
         	    tVec.dir = backward;
         	    sVec.angle -= PI;
         	}
-    	}	
+    	}
 
     	else if(acos<0)
     	{
@@ -590,11 +590,11 @@ void Triangle::getTrajectoryCoordinates(SurfaceVector& sVec,double& totalLength,
         	if (sVec.angle>2*PI)
         	    sVec.angle-= 2*PI;
     	}
-	
+
     	else
         tVec.dir = ::forward;
 
-    	// use the triangle perimeter to create a trajectory, this will to make sure to have exactly two intersections 
+    	// use the triangle perimeter to create a trajectory, this will to make sure to have exactly two intersections
     	Vector2d v1(sVec.x+periMeter*acos,sVec.y+periMeter*asin);
     	Vector2d v2(sVec.x-periMeter*acos,sVec.y-periMeter*asin);
 
@@ -628,12 +628,12 @@ void Triangle::getTrajectoryCoordinates(SurfaceVector& sVec,double& totalLength,
         	    encounter+=1;
         	    Neno = sideMap[i];
 
-                    // get triangle-edge to trajectory intersection point 
+                    // get triangle-edge to trajectory intersection point
         	    endPoint.push_back(PointATedge(u1(0,0)+sval*(u2(0,0)-u1(0,0)),u1(1,0)+sval*(u2(1,0)-u1(1,0)),0.0,Neno));
         	}
-    	}	
+    	}
 
-    	// base coordinate (x_base < x_other) of the trajectory 
+    	// base coordinate (x_base < x_other) of the trajectory
     	if(endPoint[0].x>endPoint[1].x)
     	reverse(endPoint.begin(),endPoint.end());
 
@@ -658,4 +658,3 @@ void Triangle::getTrajectoryCoordinates(SurfaceVector& sVec,double& totalLength,
 
     	return;
 }
-

--- a/src/geometry-special.cpp
+++ b/src/geometry-special.cpp
@@ -63,7 +63,7 @@ void TriMeshGeometry::outputSnapshot(ostream& out)
 
 void TriMeshGeometry::outputOrderHeatMap(ostream& out,vector<double>& localOrder,vector<Vector3d>& sv)
 {
-	for(int eno = 0; eno < localOrder.size(); eno++)
+	for(size_t eno = 0; eno < localOrder.size(); eno++)
 	{
         	Vector3d seg3D;
 
@@ -235,7 +235,7 @@ void Cartesian::getOrderParametersRawFlat(OrderParametersRaw& opR,vector<Vector3
 {		
 	double sin2(0.0),cos2(0.0);
 	Vector3d sv(0.0,0.0,0.0);
-    	double angle(0.0),length(0.0),Olength(0.0),localLength(0.);
+    	double angle(0.0),length(0.0),localLength(0.);
     	double qxx(0.0),qxy(0.0),qxz(0.0),qyy(0.0),qyz(0.0),qzz(0.0);
     	double u1(0.0),u2(0.0),u3(0.0),orderLocal(0.0);
 	MatrixXd QF(3,3),QC(3,3),e(3,3),O_l(2,2);

--- a/src/inline.cpp
+++ b/src/inline.cpp
@@ -320,4 +320,3 @@ void Region::updateRegionLength(bool forceUpdate)
 
 	return;
 }
-

--- a/src/inline.cpp
+++ b/src/inline.cpp
@@ -64,7 +64,10 @@
 			else
 				Pzip = 0.0;
 		break;
-	}
+
+        default:
+        break;
+    }
 
 	#ifdef DBG_INTERACTION_TEST
 	cout << "InteractionTest\t" << angle << "\t" << Pzip << "\t" << Pcat << "\t" << 1-Pzip-Pcat << "\n";
@@ -142,6 +145,12 @@ CollisionType System::collisionResult(double angle, int nParallel, int nCross)	/
 
 	switch(p.bundleType)
 	{
+        // TODO
+        // This needs to be fixed properly.
+        // Adding this case or `default` at the end causes an error becasue
+        // of the initialisation of multiPx & multiPz in the last case.
+        case bdl_COUNT_LAST:
+        break;
 		case bdl_noZip:
 
 			if (nParallel > 0)
@@ -215,8 +224,7 @@ CollisionType System::collisionResult(double angle, int nParallel, int nCross)	/
 
 		// though never reached
 		// break;
-
-	}
+        }
 
 	// should never occur
 	return ct_crossover;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -12,7 +12,7 @@ int main(int argc, char* argv[])
 	cout << fixed;
 	cout << setprecision(3);
    	time_t startTime = time(0);
-	
+
 	s1 = new System(argv[1]);
 
 	// run the simulation (else show the mesh statistics)
@@ -31,6 +31,3 @@ int main(int argc, char* argv[])
 	delete s1;
 	return 0;
 }
-
-
-

--- a/src/meshImport.cpp
+++ b/src/meshImport.cpp
@@ -2,9 +2,11 @@
 
 // initialize edge
 void iniEdgeRecord(struct edgeRecord *head, vector<int>& v,int cid,int fid){
+
     for(int i=0;i<2;i++)
-	head->key.push_back(v[i]);
-	head->cell_id = cid;
+	    head->key.push_back(v[i]);
+    
+    head->cell_id = cid;
 	head->edge_index = fid;
 	head->next =NULL;
 }
@@ -170,7 +172,7 @@ void pickup_shape(Geometry* g)
     	vector<elementList*> eList;
 
         int a0(0),a1(0),a2(0);
-	int vmax(0),trimax(0),id(0),spf(0),cur(0),pol(0),shw(0);
+	int vmax(0),trimax(0),spf(0),cur(0);
 	string str;
 
     	string filename;
@@ -371,7 +373,7 @@ void pickup_shape(Geometry* g)
 		element3D[23]->vertexIds[2] = 6;
 		element3D[23]->faceTag = 4;
 
-		for(int i=0;i<element3D.size();i++)
+		for(size_t i=0;i<element3D.size();i++)
 		element3D[i]->elementId = i;
     	}
 
@@ -490,7 +492,7 @@ void pickup_shape(Geometry* g)
 
 	// copy triangle elements for viewing mesh (visualization in meshLab)
 	vector<Triangle3D*>viewTriangle;
-	for(int i = 0; i < element3D.size(); i++)
+	for(size_t i = 0; i < element3D.size(); i++)
 	{
 		viewTriangle.push_back(new Triangle3D());
 		viewTriangle[i]->vertexIds[0] = element3D[i]->vertexIds[0];
@@ -529,12 +531,13 @@ void pickup_shape(Geometry* g)
 	viewGraph(Gvertex,viewTriangle,centroid,g->system->p.outputDir + "/" + g->system->p.geometry + "/outputData");
 
 	double totalArea(0.0);
-        for(int eno=0;eno<element3D.size();eno++)
-	totalArea+=element3D[eno]->area;
+    for(size_t eno=0;eno<element3D.size();eno++)
+    {
+	    totalArea+=element3D[eno]->area;
+    }
 
-
-        // show mesh in enabled
-    	if(showMesh==1)
+    // show mesh in enabled
+    if(showMesh==1)
     	{
          	cout << "============================================"<<endl;
 
@@ -615,15 +618,17 @@ void pickup_shape(Geometry* g)
         g->patchArea[0]= g->area;
 
 	// include all triangles to a single path (at first place)
-	for(int eno=0;eno<element3D.size();eno++)
-	g->RegionsIndex[0].push_back(eno);
+	for(size_t eno=0;eno<element3D.size();eno++)
+    {
+	    g->RegionsIndex[0].push_back(eno);
+    }
 
         // total number of region in the geometry
 	g->elementMax = element3D.size();
 
         // to create PPB
         // (a)  global vertex to be used to create PPB
-        for(int i=0;i< Gvertex.size();i++)
+        for(size_t i=0;i< Gvertex.size();i++)
 	{
                 g->globalVertex.push_back(Vertics(0.0,0.0,0.0));
 		g->globalVertex[i].x = Gvertex[i]->x;
@@ -632,11 +637,11 @@ void pickup_shape(Geometry* g)
 	}
 
         // (b) element list
-        for(int i=0;i< eList.size();i++)
+        for(size_t i=0;i< eList.size();i++)
 	{
 		g->ppbEdgeList.push_back(elementList());
 
-		for(int j=0;j<2;j++)
+		for(size_t j=0;j<2;j++)
 		{
     			g->ppbEdgeList[i].nodes[j] = eList[i]->nodes[j];
 			g->ppbEdgeList[i].sharedElement[j] = eList[i]->sharedElement[j];
@@ -645,35 +650,40 @@ void pickup_shape(Geometry* g)
 	}
 
         // assign memory for all the 2d-triangular regions of the geometry
-	for(int eno = 0; eno < element3D.size(); eno++)
-	g->regions.push_back(new Triangle(element3D[eno]->area,g));
+	for(size_t eno = 0; eno < element3D.size(); eno++)
+    {
+        g->regions.push_back(new Triangle(element3D[eno]->area,g));
+    }
 
 	// copy 3d-triangle properties information to 2d-triangular regions
 	Image3dTo2D(g->regions,element3D,pCatList);
 
 
-    	// 3d-triangle properties are transfered to 2d-triangular regions, so release all the memory occupied by 3d triangles
-    	for(int eno  = 0; eno < element3D.size(); eno++)
-    	{
-        	delete element3D[eno];
-    		element3D[eno] == NULL;
-    	}
-    	element3D.clear();
+    // 3d-triangle properties are transfered to 2d-triangular regions, so release all the memory occupied by 3d triangles
+    for(size_t eno  = 0; eno < element3D.size(); eno++)
+    {
+        delete element3D[eno];
+        // FOLLOW-UP
+        // This used to be a comparison (element3D[eno] == NULL).
+        // Check if the fix introduces any regressions.
+        element3D[eno] = NULL;
+    }
+    element3D.clear();
 
-	// global vertices no longer needed, so release the memories occupied by the global vertices
-    	for(int gno = 0; gno < Gvertex.size(); gno++)
-    	{
-        	delete Gvertex[gno];
-    		Gvertex[gno] = NULL;
-    	}
-    	Gvertex.clear();
+    // global vertices no longer needed, so release the memories occupied by the global vertices
+    for(size_t gno = 0; gno < Gvertex.size(); gno++)
+    {
+        delete Gvertex[gno];
+        Gvertex[gno] = NULL;
+    }
+    Gvertex.clear();
 
-        // edge list is no longer needed, so release the memories occupied by the edges
-	for(int el = 0; el < eList.size(); el++)
-    	{
-        	delete eList[el];
-    		eList[el] = NULL;
-    	}
+    // edge list is no longer needed, so release the memories occupied by the edges
+    for(size_t el = 0; el < eList.size(); el++)
+    {
+        delete eList[el];
+        eList[el] = NULL;
+    }
 	eList.clear();
 
     return;
@@ -695,7 +705,7 @@ void makeGraph(int Gvertex,vector<elementList*>& eList, vector<Triangle3D*>& ele
 
     	v.clear();
 
-    	for(int i=0;i<element3D.size();i++)
+    	for(size_t i=0;i<element3D.size();i++)
     	{
         	for(int j=0;j<3;j++)
         	element3D[i]->vertexIdsMap[element3D[i]->vertexIds[j]] = j;
@@ -726,7 +736,7 @@ void makeGraph(int Gvertex,vector<elementList*>& eList, vector<Triangle3D*>& ele
     	edge_sort(&EdgList,Gvertex);
     	find_connectivity(&EdgList,eList);
 
-    	for(int i=0;i<eList.size();i++)
+    	for(size_t i=0;i<eList.size();i++)
     	{
        	 	element3D[eList[i]->sharedElement[0]]->sideMap[eList[i]->sharedEdge[0]]=eList[i]->sharedElement[1];
         	element3D[eList[i]->sharedElement[1]]->sideMap[eList[i]->sharedEdge[1]]=eList[i]->sharedElement[0];
@@ -800,9 +810,9 @@ void correctOrientation(vector<Vertics*>& Gvertex,Triangle3D*& nextTriangle,Tria
 bool checkSurfaceOrientation(vector<Triangle3D*>& element3D)
 {
     bool match(false);
-    for(int i=0;i< element3D.size();i++)
+    for(size_t i=0;i< element3D.size();i++)
     {
-        for(int j=0;j<3;j++)
+        for(size_t j=0;j<3;j++)
         {
             match = false;
             int n = element3D[i]->sideMap[j];
@@ -854,7 +864,7 @@ void rigidBodyProperties(vector<Vertics*>& Gvertex,vector<Triangle3D*>& element3
     	double x_3,y_3,z_3;
     	double x_2y,x_2z,y_2x,y_2z,z_2y,z_2x,xyz;
 
-    	for(int eno = 0; eno < element3D.size();eno++)
+    	for(size_t eno = 0; eno < element3D.size();eno++)
     	{
 		// calculate normals to each triangle elements
         	x =  Gvertex[element3D[eno]->side[0].orientation[1]]->x- Gvertex[element3D[eno]->side[0].orientation[0]]->x;
@@ -933,7 +943,7 @@ void rigidBodyProperties(vector<Vertics*>& Gvertex,vector<Triangle3D*>& element3
     	double m110(0.0),m101(0.0),m011(0.0),m200(0.0),m020(0.0),m002(0.0);
     	double totalArea(0.0);
 
-    	for(int eno = 0; eno < element3D.size();eno++)
+    	for(size_t eno = 0; eno < element3D.size();eno++)
     	{
 		totalArea += element3D[eno]->area;
 
@@ -983,7 +993,6 @@ void rigidBodyProperties(vector<Vertics*>& Gvertex,vector<Triangle3D*>& element3
     	double matrix[3][3] = {{Ixx,-Ixy,-Ixz},{-Ixy,Iyy,-Iyz},{-Ixz,-Iyz,Izz}};
     	double evecMat[3][3];
     	double eVal[3];
-    	int minPos;
 
     	eigen_decomposition(matrix,evecMat,eVal);
 
@@ -1014,7 +1023,7 @@ void rigidBodyProperties(vector<Vertics*>& Gvertex,vector<Triangle3D*>& element3
 	}
 
 	// change the global coordiantes w.r.t. centroid
-    	for(int gno=0;gno<Gvertex.size();gno++)
+    	for(size_t gno=0;gno<Gvertex.size();gno++)
     	{
         	Gvertex[gno]->x-=cm(0,0);
         	Gvertex[gno]->y-=cm(1,0);
@@ -1023,7 +1032,7 @@ void rigidBodyProperties(vector<Vertics*>& Gvertex,vector<Triangle3D*>& element3
 
     	// make the surface normals (to each triangle elements) oriented outwards
 	double dsum(0.0);
-        for(int i =0;i< 3;i++)
+        for(size_t i =0;i< 3;i++)
 	{
                 x = Gvertex[element3D[0]->side[i].orientation[1]]->x - Gvertex[element3D[0]->side[i].orientation[0]]->x;
                 y = Gvertex[element3D[0]->side[i].orientation[1]]->y + Gvertex[element3D[0]->side[i].orientation[0]]->y;
@@ -1033,8 +1042,10 @@ void rigidBodyProperties(vector<Vertics*>& Gvertex,vector<Triangle3D*>& element3
 	// sign of the area of the triangle is negative (<0), i.e. triangle vertex orientation clock-wise, normal needs to be flipped
         if(dsum > 0)
 	{
-                for(int eno=0;eno<element3D.size();eno++)
-        	element3D[eno]->givenNormal*=-1.0;
+            for (size_t eno = 0; eno < element3D.size (); eno++)
+            {
+                element3D[eno]->givenNormal*=-1.0;
+            }
 
 	}
 }
@@ -1044,10 +1055,10 @@ void edgeDescriptors(vector<Vertics*>& Gvertex,vector<elementList*> & eList,vect
         // edge descriptors
 
 	int eno,neno,p1,p2;
-    	double x,y,z,signal,edgeAngle,cosTheta,sinTheta;
+    	double x,y,z,signal,edgeAngle;
 
 	// calculate the 3D-edge angles and angle-axis pairs
-    	for(int i=0;i<eList.size();i++)
+    	for(size_t i=0;i<eList.size();i++)
     	{
         	x = Gvertex[eList[i]->nodes[0]]->x-Gvertex[eList[i]->nodes[1]]->x;
         	y = Gvertex[eList[i]->nodes[0]]->y-Gvertex[eList[i]->nodes[1]]->y;
@@ -1096,11 +1107,11 @@ void edgeDescriptors(vector<Vertics*>& Gvertex,vector<elementList*> & eList,vect
     	}
 
 	/// Calculate perimeter for each triangle elements
-    	for(int eno=0;eno< element3D.size(); eno++)
+    	for(size_t eno=0;eno< element3D.size(); eno++)
     	{
         	double l(0.0);
 
-        	for(int sid=0;sid<3;sid++)
+        	for(size_t sid=0;sid<3;sid++)
         	{
             		l+= eList[element3D[eno]->sideToEdge[sid]]->length;
 
@@ -1115,7 +1126,7 @@ void edgeDescriptors(vector<Vertics*>& Gvertex,vector<elementList*> & eList,vect
 void connectWithGlobe(vector<Vertics*>& Gvertex,vector<Triangle3D*>& element3D)
 {
 	// link the global coordinates to the triangles
-	for(int eno=0;eno<element3D.size();eno++)
+	for(size_t eno=0;eno<element3D.size();eno++)
     	{
         	element3D[eno]->Vertex[0] << Gvertex[element3D[eno]->vertexIds[0]]->x,Gvertex[element3D[eno]->vertexIds[0]]->y,Gvertex[element3D[eno]->vertexIds[0]]->z;
         	element3D[eno]->Vertex[1] << Gvertex[element3D[eno]->vertexIds[1]]->x,Gvertex[element3D[eno]->vertexIds[1]]->y,Gvertex[element3D[eno]->vertexIds[1]]->z;
@@ -1135,9 +1146,8 @@ void Image3dTo2D(vector<Region*> &regions,vector<Triangle3D*> &element3D, double
     Vector3d cross;
     double cosAngle(0.0);
     double crossMagnitude(0.0);
-    bool match(false);
 
-    for(int eno = 0; eno < element3D.size(); eno++)
+    for(size_t eno = 0; eno < element3D.size(); eno++)
     {
         // quarternion rotation angle (cosine)
         cosAngle = element3D[eno]->givenNormal.dot(z);
@@ -1225,19 +1235,15 @@ void Image3dTo2D(vector<Region*> &regions,vector<Triangle3D*> &element3D, double
         nz/=nz.norm();
         double s = nz.dot(z);
 
-        if(s>0)
-        match = true;
-
-        else
+        if(s<=0)
         {
-            match = false;
             cout << "Normals not aligned towards z (anti-parallel to) axis !!! emergency exit"<<endl;
             exit(-1);
         }
 
         // change the local coordinate frame to the Center of Mass frame
         regions[eno]->midPoint = (regions[eno]->Vertics[0]+regions[eno]->Vertics[1]+regions[eno]->Vertics[2])/3.0;
-        for(int i=0;i<3;i++)
+        for(size_t i=0;i<3;i++)
         regions[eno]->Vertics[i]-=regions[eno]->midPoint;
 
         // assign the necessary components from 3d-triangle to 2d-triangle
@@ -1264,12 +1270,11 @@ void Image3dTo2D(vector<Region*> &regions,vector<Triangle3D*> &element3D, double
     Vector2d b1,b2;
     int v0,v1,v2;
     double cosTheta,sinTheta,x,y;
-    match = false;
 
     // calculate the rotation angle between two 2d-triangle side
-    for(int eno=0;eno<element3D.size();eno++)
+    for(size_t eno=0;eno<element3D.size();eno++)
     {
-        for(int j=0;j<3;j++)
+        for(size_t j=0;j<3;j++)
         {
             int ceno = regions[eno]->sideMap[j];
             int cesd = regions[ceno]->sideRevMap[regions[eno]->regionId];
@@ -1307,12 +1312,8 @@ void Image3dTo2D(vector<Region*> &regions,vector<Triangle3D*> &element3D, double
 
             MatrixXd G =A1.inverse();
 
-            if(fabs(A1.determinant()*A2.determinant())>0.0)
-            match = true;
-
-            else
+            if(fabs(A1.determinant()*A2.determinant())<=0.0)
             {
-                match = false;
                 cout << "Affine matrix with Determinant = 0.0, is detected !!! emergency exit"<<endl;
                 exit(-1);
             }
@@ -1348,7 +1349,7 @@ void Image3dTo2D(vector<Region*> &regions,vector<Triangle3D*> &element3D, double
         }
 
         // get the orientation axis (required for calculating the order parameter)
-	vector<Vector3d> ends3D;
+	    vector<Vector3d> ends3D;
     	for(int p = 0;p < 2;p++)
     	ends3D.push_back(Vector3d(0,0,0));
 
@@ -1359,7 +1360,7 @@ void Image3dTo2D(vector<Region*> &regions,vector<Triangle3D*> &element3D, double
         y = 0.0;
 
         // first two (=2) base vactor : rotate 2-d (x-axis and y-axis) -> triangle normal plane
-        for(int ax = 0;ax < 2;ax++)
+        for(size_t ax = 0;ax < 2;ax++)
         {
             cross << regions[eno]->Q.x(),regions[eno]->Q.y(),regions[eno]->Q.z();
             crossMagnitude = cross.norm();
@@ -1423,13 +1424,13 @@ void viewGraph(vector<Vertics*>& Gvertex,vector<Triangle3D*>& element3D,Vector3d
 	fp1 << "OFF" <<endl;
 	fp1 << Gvertex.size() << " "<< element3D.size() << " " << 0 <<endl;
 
-	for(int i=0;i<Gvertex.size();i++)
+	for(size_t i=0;i<Gvertex.size();i++)
 	fp1 << Gvertex[i]->x + centroid(0,0) << " " << Gvertex[i]->y + centroid(1,0) << " " << Gvertex[i]->z + centroid(2,0) <<endl;
 
-        for(int i=0;i<element3D.size();i++)
+        for(size_t i=0;i<element3D.size();i++)
 	{
 		fp1 << 3 << " ";
-		for(int j =0;j<3;j++)
+		for(size_t j =0;j<3;j++)
 		fp1 << element3D[i]->vertexIds[j] << " ";
 		fp1  <<endl;
 
@@ -1546,12 +1547,17 @@ double intersectingPolygon(vector<Vertics>& polygon,vector<Vertics>& Gvertex,vec
 	{
 		polygon.clear();
 
-		for(int eno=0;eno< regions.size();eno++)
-		regions[eno]->polyIntersectMark==0;
+		for(size_t eno=0;eno< regions.size();eno++)
+        {
+            // FOLLOW-UP
+            // This used to be a comparison (regions[eno]->polyIntersectMark==0).
+            // Check if the fix introduces any regressions.
+            regions[eno]->polyIntersectMark=0;
+        }
 
 		vector<int> intersectedEdges;
 		double x,y,z;
-		for(int i =0;i< eList.size();i++)
+		for(size_t i =0;i< eList.size();i++)
 		{
 		        x = Gvertex[eList[i].nodes[0]].x;
 		        y = Gvertex[eList[i].nodes[0]].y;
@@ -1574,7 +1580,7 @@ double intersectingPolygon(vector<Vertics>& polygon,vector<Vertics>& Gvertex,vec
 		        }
 		}
 
-		for(int i =0;i< intersectedEdges.size();i++)
+		for(size_t i =0;i< intersectedEdges.size();i++)
 		{
 		        int edg = intersectedEdges[i];
 
@@ -1607,7 +1613,7 @@ double intersectingPolygon(vector<Vertics>& polygon,vector<Vertics>& Gvertex,vec
 		}
 
 		// construct polygon
-		for(int i =0; i< polygonEdg.size();i++)
+		for(size_t i =0; i< polygonEdg.size();i++)
 		{
 		        int edg = polygonEdg[i];
 			Vector3d pv = eList[edg].intersectionByPlane;
@@ -1620,11 +1626,11 @@ double intersectingPolygon(vector<Vertics>& polygon,vector<Vertics>& Gvertex,vec
 		intersectedEdges.clear();
 		polygonEdg.clear();
 
-		for(int i=0;i<  regions.size() ;i++)
+		for(size_t i=0;i<  regions.size() ;i++)
 		regions[i]->intersectEdg.clear();
 
-		return(polyArea);
 	}
+    return(polyArea);
 }
 
 vector<string> split(string str, char delimiter) {
@@ -1646,7 +1652,7 @@ void establishPBC(vector<Vertics*>& vertices,vector<Triangle3D*>& triangles,vect
 	vector<int>edgeInMesh,edgeInBoundary;
 
 	/// find the boundary edges
-	for(int i=0;i<eList.size();i++)
+	for(size_t i=0;i<eList.size();i++)
 	{
 		bool hitorigin(eList[i]->nodes[1]==5);
 
@@ -1659,7 +1665,7 @@ void establishPBC(vector<Vertics*>& vertices,vector<Triangle3D*>& triangles,vect
 
 	int firstBT=triangles.size()-bCount;
 
-	for(int i=0;i<edgeInMesh.size();i++)
+	for(size_t i=0;i<edgeInMesh.size();i++)
 	{
 		int n1 = eList[edgeInMesh[i]]->sharedElement[0];
 		int n2 = eList[edgeInMesh[i]]->sharedElement[1];
@@ -1682,7 +1688,7 @@ void establishPBC(vector<Vertics*>& vertices,vector<Triangle3D*>& triangles,vect
 
 	/// boundary edge (clock/anti-clock wise) sorting
 	int vid(vertices.size()-1);
-	for(int i=0;i<edgeInBoundary.size();i++)
+	for(size_t i=0;i<edgeInBoundary.size();i++)
 	{
 		vid++;
 		eList[edgeInBoundary[i]]->midPoint = vid;
@@ -1695,10 +1701,9 @@ void establishPBC(vector<Vertics*>& vertices,vector<Triangle3D*>& triangles,vect
 		vertices.push_back(new Vertics(vm(0,0),vm(1,0),vm(2,0)));
 	}
 
-	double elementDistance;
 	vector<double> edgePositionBoundary;
 
-	for(int i=0;i<edgeInBoundary.size();i++)
+	for(size_t i=0;i<edgeInBoundary.size();i++)
 	{
                 Vector2d radialExt(vertices[eList[edgeInBoundary[i]]->midPoint]->x,vertices[eList[edgeInBoundary[i]]->midPoint]->y);
                 radialExt/=radialExt.norm();
@@ -1715,20 +1720,20 @@ void establishPBC(vector<Vertics*>& vertices,vector<Triangle3D*>& triangles,vect
 	}
 
 	/// remove un-necessary vertices
-        for(int i=0;i<=edgeInBoundary.size();i++)
+        for(size_t i=0;i<=edgeInBoundary.size();i++)
         vertices.pop_back();
 
 	vector<pair<double,int> > vp;
 	vp.reserve(edgePositionBoundary.size());
 
-	for(int i = 0 ; i != edgePositionBoundary.size() ; i++)
+	for(size_t i = 0 ; i != edgePositionBoundary.size() ; i++)
 	vp.push_back(make_pair(edgePositionBoundary[i],i));
 	edgePositionBoundary.clear();
 
 	sort(vp.begin(),vp.end());
 
 	vector<int> indexBoundary;
-	for(int i=0;i<vp.size();i++)
+	for(size_t i=0;i<vp.size();i++)
 	indexBoundary.push_back(vp[i].second);
 
 	int n1,n2,p1,p2,e1,e2,s1,s2,l1,l2;

--- a/src/meshImport.cpp
+++ b/src/meshImport.cpp
@@ -5,7 +5,7 @@ void iniEdgeRecord(struct edgeRecord *head, vector<int>& v,int cid,int fid){
 
     for(int i=0;i<2;i++)
 	    head->key.push_back(v[i]);
-    
+
     head->cell_id = cid;
 	head->edge_index = fid;
 	head->next =NULL;
@@ -1821,4 +1821,3 @@ void establishPBC(vector<Vertics*>& vertices,vector<Triangle3D*>& triangles,vect
 
     	indexBoundary.clear();
 }
-

--- a/src/meson.build
+++ b/src/meson.build
@@ -9,4 +9,3 @@ sources = files('eig3.cpp',
     'geometry-special.cpp',
     'main.cpp'
 )
-

--- a/src/microtubule.cpp
+++ b/src/microtubule.cpp
@@ -5,7 +5,7 @@ Microtubule::Microtubule(System* s, TrajectoryVector tv, bool initialize)
       plus(this, tv, s->p.vPlus, &(s->vPlusQueue), s->p.vPlus),
 
       // reverse direction
-      minus(this, tv.flipped(), -s->p.vTM, &(s->timeQueue), -s->p.vTM),	
+      minus(this, tv.flipped(), -s->p.vTM, &(s->timeQueue), -s->p.vTM),
       disappearEvent(this, &(s->timeQueue), - s->p.vMin + s->p.vTM),
       type(mt_growing),
       nucleationTime(s->systemTime + s->systemTimeOffset),
@@ -56,7 +56,7 @@ Microtubule::~Microtubule()
 void Microtubule::setDisappearEvent()
 {
     // push to disappear event: (plus.velocity - minus.velocity < 0)
-    if ((segments.size() == 1) && (type == mt_shrinking)) 
+    if ((segments.size() == 1) && (type == mt_shrinking))
         disappearEvent.pushOnQueue(segments.first()->length(), ev_disappear);
 
     // flush disappear event queue
@@ -67,7 +67,7 @@ void Microtubule::setDisappearEvent()
 
 void Microtubule::handleEvent(const EventDescriptor* ei)
 {
-    // better update length before processing next event 
+    // better update length before processing next event
     updateLength();
 
     #ifdef DBG_ACID_TEST
@@ -80,12 +80,12 @@ void Microtubule::handleEvent(const EventDescriptor* ei)
 
     switch(ei->type)
     {
-        // wall collision event encountered 
+        // wall collision event encountered
     	case ev_wall:
         	wall();
         break;
 
-	// MT-MT collision event encountered 
+	// MT-MT collision event encountered
     	case ev_collision:
         	collision();
         break;
@@ -143,22 +143,22 @@ void Microtubule::catastrophe()
     // update MT length
     updateLength();
 
-    // growing MT will become shrinking MT, hence unregister the tip from growing-plus-tip list of this region 
+    // growing MT will become shrinking MT, hence unregister the tip from growing-plus-tip list of this region
     plus.trajectory->base.region->unregisterFromRegion(plus.regionTag,t_plus,mt_growing);
 
-    // now, this is shrinking MT 
+    // now, this is shrinking MT
     type = mt_shrinking;
 
-    // growing MT will become shrinking MT, hence register the tip on shrinking-plus-tip list of this region 
+    // growing MT will become shrinking MT, hence register the tip on shrinking-plus-tip list of this region
     plus.regionTag = plus.trajectory->base.region->registerOnRegion(&plus,t_plus,mt_shrinking);
 
-    // replace plus velocity by minus velocity  
+    // replace plus velocity by minus velocity
     plus.velocity = system->p.vMin;
 
-    // 
+    //
     plus.event.reinitialize(&(system->timeQueue),system->p.vMin);
 
-    // import the growing MT as shrinking MT 
+    // import the growing MT as shrinking MT
     system->shrinking_mts.import(system->growing_mts, this);
 
     if (system->p.vMin < 0)
@@ -170,7 +170,7 @@ void Microtubule::catastrophe()
     // schedule next event, (if this is triggered by a collision, and vMin > 0, increase occupancy)
     plus.determineEvent();
 
-    // check possibility of a disappear event 
+    // check possibility of a disappear event
     setDisappearEvent();
 
     return;
@@ -192,16 +192,16 @@ void Microtubule::rescue()
 
     updateLength();
 
-    // shrinking MT will become growing  MT, hence unregister the tip from shrinking-plus-tip list of this region 
+    // shrinking MT will become growing  MT, hence unregister the tip from shrinking-plus-tip list of this region
     plus.trajectory->base.region->unregisterFromRegion(plus.regionTag,t_plus,mt_shrinking);
 
-    // now, this is growing MT 
+    // now, this is growing MT
     type = mt_growing;
 
     // shrinking MT will become growing MT, hence register the tip on growing-plus-tip list of this region
     plus.regionTag = plus.trajectory->base.region->registerOnRegion(&plus,t_plus,mt_growing);
 
-    // replace minue velocity by plus velocity 
+    // replace minue velocity by plus velocity
     plus.velocity = system->p.vPlus;
 
     plus.event.reinitialize(&(system->vPlusQueue), system->p.vPlus);
@@ -369,7 +369,7 @@ void Microtubule::translatePositionMT2Segment(double& cutPos, Segment*& cutSeg)
 
 void Microtubule::wall()
 {
-    // only for plus end 
+    // only for plus end
 
     TrajectoryVector tv;
 
@@ -387,17 +387,17 @@ void Microtubule::wall()
         return;
     }
 
-    // edge catastrophe enabled 
+    // edge catastrophe enabled
     if (system->p.edgeCatastropheEnabled)
     {
         double cosAngle = (plus.dir == ::forward) ? plus.trajectory->nextTrCosAngle : plus.trajectory->prevTrCosAngle;
 
-        // MT is moving non-parallel to the edege 
+        // MT is moving non-parallel to the edege
         if ((1.0 - cosAngle) > ZERO_CUTOFF)
-        {          
+        {
             double pCat(0.0);
-	    
-	    // for sharp edged cube 
+
+	    // for sharp edged cube
 	    if(system->p.geometry == "cubeReal")
 	    {
 		if(abs(plus.trajectory->base.region->faceTag - tv.trajectory->base.region->faceTag) > 0)
@@ -410,17 +410,17 @@ void Microtubule::wall()
 		}
 	    }
 
-	    // other  
+	    // other
             else
-	    pCat = (plus.dir == ::forward) ? plus.trajectory->nextTrpCat : plus.trajectory->prevTrpCat; 
+	    pCat = (plus.dir == ::forward) ? plus.trajectory->nextTrpCat : plus.trajectory->prevTrpCat;
 
-            // when smooth catastrophe is enabled 
+            // when smooth catastrophe is enabled
             if(system->p.edgeCatastropheSmooth)
             {
                 pCat *= (1.0 - cosAngle);
             }
 
-            // apply catastrophe 
+            // apply catastrophe
             if (system->randomGen.rand() <= pCat)
             {
                 tv.trajectory->conditionalRemove();
@@ -432,7 +432,7 @@ void Microtubule::wall()
         }
     }
 
-    // update boundarty crossing count 
+    // update boundarty crossing count
     system->boundaryCrossingCount++;
 
     #ifdef DBG_ASSERT
@@ -440,19 +440,19 @@ void Microtubule::wall()
         cerr << "DBG/ASSERT: nextCollision does not match with endItr upon entering wall event.\n";
     #endif
 
-    // wall crossing 
+    // wall crossing
     segments.last()->endItr = plus.nextCollision;
 
-    // create a new segment 
+    // create a new segment
     segments.create(this, tv);
     segments.last()->startItr = tv.dir == ::forward ? tv.trajectory->wallBegin() : tv.trajectory->wallEnd();
 
-    // switch trajectory 
+    // switch trajectory
     plus.switchTrajectory(tv.trajectory, tv.dir, tv.dir == ::forward ? tv.trajectory->wallBegin() : tv.trajectory->wallEnd());
 
     if (segments.size() == 2)
     {
-        // MT with two segment of zero (=0) length, consider possibilty of a disappear event 
+        // MT with two segment of zero (=0) length, consider possibilty of a disappear event
         minus.determineEvent();
         setDisappearEvent();
     }
@@ -467,11 +467,11 @@ void Microtubule::collision()
     CollisionType type;
     Direction dir;
 
-    // no MT(s) passing throught the next collision point, resulting a simple crossover 
+    // no MT(s) passing throught the next collision point, resulting a simple crossover
     if (plus.nextCollision->second.mirror->second.occupancy == 0)
         type = ct_crossover;
 
-    // MT(s) passing through the next collision point  
+    // MT(s) passing through the next collision point
     else
     {
         double diffAngle = plus.trajectory->base.region->intersectionAngle(plus.trajectory, plus.nextCollision->second.otherTrajectory);
@@ -483,20 +483,20 @@ void Microtubule::collision()
         }
         else
         	dir = plus.dir;
-	
-	// find out type of collision event to be occured 
+
+	// find out type of collision event to be occured
         type = system->collisionResult(diffAngle, plus.nextCollision->second.occupancy, plus.nextCollision->second.mirror->second.occupancy);
     }
 
     switch(type)
     {
-	// zippering 
+	// zippering
     	case ct_zipper:
         	system->totalZipperCount++;
         	zipper(dir);
         break;
 
-	// crossover 
+	// crossover
     	case ct_crossover:
         	system->totalCrossoverCount++;
         	crossover();
@@ -546,7 +546,7 @@ void Microtubule::zipper(Direction dir)
 
     if (segments.size() == 2)
     {
-        // number of segment is two (=2), HERE it means two zero length segment, prepare to schedule a disappear event 
+        // number of segment is two (=2), HERE it means two zero length segment, prepare to schedule a disappear event
         minus.determineEvent();
         setDisappearEvent();
     }
@@ -568,7 +568,7 @@ void Microtubule::endOfSegment(MTTip* tip)
 	Segment* newSeg(NULL);
 	Segment* killSeg(NULL);
 
-        // select plus tip associated segment 
+        // select plus tip associated segment
 	if (tip == &plus)
 	{
 		killSeg = segments.last();
@@ -576,7 +576,7 @@ void Microtubule::endOfSegment(MTTip* tip)
 		newDir = newSeg->dir;
 	}
 
-        // select minus tip associated segment 
+        // select minus tip associated segment
 	else
 	{
 		killSeg = segments.first();
@@ -595,32 +595,32 @@ void Microtubule::endOfSegment(MTTip* tip)
     }
     #endif
 
-    // kill the selected segment 
+    // kill the selected segment
     segments.remove(killSeg);
 
-    // tip switching to a new trajectory (in a different region) after encountering wall-begin/wall-end 
+    // tip switching to a new trajectory (in a different region) after encountering wall-begin/wall-end
     if ((tip->nextCollision == tip->trajectory->wallBegin()) ||(tip->nextCollision == tip->trajectory->wallEnd()))
     {
         tip->switchTrajectory(newSeg->trajectory, newDir, newDir == ::forward ? newSeg->trajectory->wallEnd() : newSeg->trajectory->wallBegin());
         system->boundaryCrossingCount--;
     }
 
-    // tip switching to a new trajectory (in the same region) 
+    // tip switching to a new trajectory (in the same region)
     else
         tip->switchTrajectory(tip->nextCollision->second.otherTrajectory, newDir, tip->nextCollision->second.mirror);
 
     // MT length zero (=0) encountered
     if (segments.size()==1)
     {
-        // current tip is a plus tip, so determine the minus tip associated event 
+        // current tip is a plus tip, so determine the minus tip associated event
         if (tip == &(plus))
             minus.determineEvent();
 
-        // current tip is a minus tip, so determine the plus tip associated event 
+        // current tip is a minus tip, so determine the plus tip associated event
         else
             plus.determineEvent();
 
-        // schedule a disappear event 
+        // schedule a disappear event
         setDisappearEvent();
     }
 
@@ -629,14 +629,14 @@ void Microtubule::endOfSegment(MTTip* tip)
 
 void Microtubule::backtrack(MTTip* tip)
 {
-    // asociated with depolymerizing plus/minus end 
+    // asociated with depolymerizing plus/minus end
 
     if (tip == &(plus))
         segments.last()->end = plus.nextEventPos;
     else
         segments.first()->start = minus.nextEventPos;
 
-    // MT is back tracked from this site, resulting a decrease in occupancy 
+    // MT is back tracked from this site, resulting a decrease in occupancy
     tip->nextCollision->second.occupancy--;
 
     #ifdef CROSS_SEV
@@ -674,7 +674,7 @@ void Microtubule::backtrack(MTTip* tip)
     }
     #endif
 
-    // schedule next event 
+    // schedule next event
     tip->advanceIntersection();
     tip->determineEvent();
 
@@ -698,7 +698,7 @@ void Microtubule::crossover()
     }
     #endif
 
-    // skip any (active) event in the current intersection point, instead move the tip to the next intersection point 
+    // skip any (active) event in the current intersection point, instead move the tip to the next intersection point
     plus.nextCollision->second.occupancy++;
     plus.advanceIntersection();
     plus.determineEvent();
@@ -756,7 +756,7 @@ bool Microtubule::integrityCheck()
         {
             if (seg->endItr->second.mirror != seg->next()->startItr)
             {
-                // next-start-iterator should match with the end-second-mirror-iterator 
+                // next-start-iterator should match with the end-second-mirror-iterator
                 valid = false;
                 cerr << "reciprocity violated\n";
             }
@@ -840,7 +840,7 @@ bool Microtubule::integrityCheck()
     {
         if (plus.nextCollision == plus.trajectory->wallEnd())
         {
-            // segment end location does not coincide with the first intersection site 
+            // segment end location does not coincide with the first intersection site
             if (segments.last()->end - plus.trajectory->length > ZERO_CUTOFF)
                 valid = false;
         }
@@ -1038,7 +1038,7 @@ Segment::Segment(Microtubule* m, TrajectoryVector& tv)
     cout << "begin position: " << start << ", end position: " << end << "\n";
     #endif
 
-    // insert this segment to the associated MT trajectory 
+    // insert this segment to the associated MT trajectory
     trajectoryTag = tv.trajectory->insertSegment(this);
 
     // increase total number of segments for the associated MT
@@ -1052,7 +1052,7 @@ Segment::~Segment()
     cout << "DBG/MTS: Segment destroyed.\n";
     #endif
 
-    // decrease total number of segments for the associated MT 
+    // decrease total number of segments for the associated MT
     mt->system->countSegments--;
 
     // if this is the last segment, remove the tip references...
@@ -1120,10 +1120,10 @@ MTTip::~MTTip()
 
 void MTTip::initialize()
 {
-    // register the tip for notification in the current trajectory 
+    // register the tip for notification in the current trajectory
     notificationTag = trajectory->registerForNotifications(this);
 
-    // get the region tag of the tip 
+    // get the region tag of the tip
     regionTag = trajectory->base.region->registerOnRegion(this,type(),mt->type);
 
     // locate the next intersection position of the tip
@@ -1236,7 +1236,7 @@ void MTTip::determineEvent()
     // get the current position of the tip on the trajectory
     double pos = position();
 
-    // a tip that is polymerizing 
+    // a tip that is polymerizing
     if (velocity > 0)
     {
         // next collision on wall begenning (at the bottom of the trajectory)
@@ -1253,7 +1253,7 @@ void MTTip::determineEvent()
             eventPos = trajectory->length;
         }
 
-        // next collision, some where at the middle of trajectory 
+        // next collision, some where at the middle of trajectory
         else
         {
             eventType = ev_collision;
@@ -1261,8 +1261,8 @@ void MTTip::determineEvent()
         }
     }
 
-    // a tip that is either paused or depolymerizing 
-    else  
+    // a tip that is either paused or depolymerizing
+    else
     {
         // next collision on wall begenning (at the bottom of the trajectory)
         if (nextCollision == trajectory->wallBegin())
@@ -1307,7 +1307,7 @@ void MTTip::determineEvent()
     // store the event with: (a) type of event and (b) distance to travel
     event.pushOnQueue((eventPos - pos)*dir, eventType);
 
-    // transfer the value of the calculated event position to the next event position 
+    // transfer the value of the calculated event position to the next event position
     nextEventPos = eventPos;
 
     #ifdef DBG_EVENT
@@ -1328,7 +1328,7 @@ void MTTip::notifyRemove(IntersectionItr& oldIs)
     // update the length of MT
     mt->updateLength();
 
-     // scheduled next collision is at this invalid intersection point, so skip it to reach the next intersection point 
+     // scheduled next collision is at this invalid intersection point, so skip it to reach the next intersection point
     if (oldIs == nextCollision)
     {
         advanceIntersection();
@@ -1338,7 +1338,7 @@ void MTTip::notifyRemove(IntersectionItr& oldIs)
     // get the tip start/end iterator
     IntersectionItr& ref = (type() == t_plus) ? mt->segments.last()->endItr : mt->segments.first()->startItr;
 
-     // link the tip start/end iterator to the new inserted iterator 
+     // link the tip start/end iterator to the new inserted iterator
     if (ref == oldIs)
     {
         if (dir == ::forward)
@@ -1353,15 +1353,15 @@ void MTTip::notifyRemove(IntersectionItr& oldIs)
 void MTTip::notifyInsert(IntersectionItr& newIs)
 {
 
-    // update the MT 
+    // update the MT
     mt->updateLength();
 
     IntersectionItr temp = newIs;
-    
+
     // next collission site in front
     if ((dir*velocity > 0) || ((velocity == 0) && (dir==backward)))
     {
-        // if the scheduled next collision is located after the new intersection point,  then replace it by the new intersection 
+        // if the scheduled next collision is located after the new intersection point,  then replace it by the new intersection
         if ((++temp == nextCollision) && (newIs->first > position()))
         {
             nextCollision = newIs;
@@ -1372,7 +1372,7 @@ void MTTip::notifyInsert(IntersectionItr& newIs)
     // next collission site in back
     else
     {
-        // if the scheduled next collision is located after the new intersection point,  then replace it by the new intersection 
+        // if the scheduled next collision is located after the new intersection point,  then replace it by the new intersection
         if ((--temp == nextCollision) && (newIs->first < position()))
         {
             nextCollision = newIs;
@@ -1385,10 +1385,10 @@ void MTTip::notifyInsert(IntersectionItr& newIs)
     // get the tip start/end iterator
     IntersectionItr& refItr = (type() == t_plus) ? mt->segments.last()->endItr : mt->segments.first()->startItr;
 
-    // get the tip start/end position 
+    // get the tip start/end position
     double& refPos = (type() == t_plus) ? mt->segments.last()->end : mt->segments.first()->start;
 
-    // link the tip start/end iterator to the new inserted iterator 
+    // link the tip start/end iterator to the new inserted iterator
     if (dir == ::forward)
     {
         if ((++temp == refItr) && (newIs->first > refPos))
@@ -1424,7 +1424,7 @@ double MTTip::position()
 
 double MTTip::otherPosition()
 {
-    // get the (bottom) position of an active segment 
+    // get the (bottom) position of an active segment
     if (this == &(mt->minus))
         return mt->segments.first()->end;
     else
@@ -1433,7 +1433,7 @@ double MTTip::otherPosition()
 
 Segment& MTTip::segment()
 {
-    // get the current segement of the tip 
+    // get the current segement of the tip
     if (this == &(mt->minus))
         return *(mt->segments.first());
     else
@@ -1446,10 +1446,10 @@ void MTTip::switchTrajectory(Trajectory* newTr, Direction d, IntersectionItr int
     // copy old trajectory of the tip (required to unregister the tip from old trajectory region)
     Trajectory* oldTr(trajectory);
 
-    // assign new trajectory to the tip 
+    // assign new trajectory to the tip
     trajectory = newTr;
 
-    // assign new direction to the tip 
+    // assign new direction to the tip
     dir = d;
     nextCollision = intersect;
 
@@ -1460,7 +1460,7 @@ void MTTip::switchTrajectory(Trajectory* newTr, Direction d, IntersectionItr int
     // assign an event to the tip
     determineEvent();
 
-    // unregister the tip from old trajectory 
+    // unregister the tip from old trajectory
     oldTr->base.region->unregisterFromRegion(regionTag,type(),mt->type);
 
     // find the new regiontag of the tip
@@ -1477,4 +1477,3 @@ void MTTip::switchTrajectory(Trajectory* newTr, Direction d, IntersectionItr int
 
     return;
 }
-

--- a/src/microtubule.cpp
+++ b/src/microtubule.cpp
@@ -111,6 +111,8 @@ void Microtubule::handleEvent(const EventDescriptor* ei)
         	harakiri();
         break;
 
+        case ev_none:
+        break;
     };
 
     #ifdef DBG_ACID_TEST
@@ -722,7 +724,7 @@ bool Microtubule::integrityCheck()
 
     Segment* seg(NULL);
     IntersectionItr is;
-    int count(0);
+    size_t count(0);
 
     // check connections between end-of segment iterators and match with positions (should be exact)
     if (segments.size() == 0)
@@ -1023,11 +1025,11 @@ bool Microtubule::integrityCheck()
 Segment::Segment(Microtubule* m, TrajectoryVector& tv)
     : mt(m),
       trajectory(tv.trajectory),
-      start(tv.pos),
-      end(tv.pos),
-      dir(tv.dir),
       trajectoryTag(tv.trajectory->segments.end()),
       nucleationTime(m->system->systemTime + m->system->systemTimeOffset),
+      dir(tv.dir),
+      start(tv.pos),
+      end(tv.pos),
       startItr(tv.trajectory->wallEnd()),
       endItr(tv.trajectory->wallEnd())
 {

--- a/src/parameters.cpp
+++ b/src/parameters.cpp
@@ -11,36 +11,35 @@ Parameters::Parameters(System* s) :
     vMin(-0.16),
     vTM(0.01),
     kSev(0.001),
-    geometryScaleFactor(15.0),
     kCross(0.001),
     kCat(0.005),
     kRes(0.007),
+    kNuc(0.001),
+    PPBformingTime(VERY_LARGE),
     poolDensity(5.0),
     treadmillingEnabled(1),
     severingEnabled(0),
     crossSeveringEnabled(0),
+    crossSeveringTop(1),
+    crossSeveringStartAngle(0),
+    PPB(0),
+    restrictedPool(0),
     edgeCatastropheEnabled(0),
     edgeCatastropheSmooth(0),
     pCatSpecialEdgeMax(0.0),
     pCatRegularEdgeMax(0.0),
     edgNumber(0),
     faceNumber(0),
-    kNuc(0.001),
     nucleationType(nuc_isotropic),
-    interactionType(int_zipFirst),
     zipperingEnabled(1),
     catastrophesEnabled(1),
-    PPB(0),
-    PPBformingTime(VERY_LARGE),
     proportionalCatastrophes(0),
     inducedCatastropheFraction(0.5),
-    catStartAngle(0),
     zipFraction(1.0),
     PPBkNucFraction(0.0),
+    catStartAngle(0),
     magicAngle(40),
-    crossSeveringTop(1),
-    crossSeveringStartAngle(0),
-    restrictedPool(0),
+    interactionType(int_zipFirst),
     bundleType(bdl_simple),
     geomParam("0"),
     seed(time(0)),
@@ -48,19 +47,20 @@ Parameters::Parameters(System* s) :
     measurementInterval(600),
     wallClockLimit(1000),
     memoryLimit(10000000),
-    outputDir("."),
     inputDir("."),
+    outputDir("."),
     createSubdir(1),
     newParameterReadInterval(VERY_LARGE),
     newParameterFile(""),
-    movieEnabled(0),			
-    movieFrameInterval(-1),
-    geometry ("2D-plane_1_0_0"),
-    showMesh(0),
+    movieEnabled(0),
     showOutput(0),
+    showMesh(0),
+    geometry ("2D-plane_1_0_0"),
+    movieFrameInterval(-1),
+    geometryScaleFactor(15.0),
     c0calc(0),
     x0calc(0),
-    z0calc(0)		
+    z0calc(0)
 {
     return;
 }
@@ -364,8 +364,6 @@ bool Parameters::readFromFile(const char* pf, bool initialRun)
 
 void Parameters::verifyParameters()
 {
-    int i;
-
     // adjust the parameter values in accordance with the swith (on/off) values
     vTM *= treadmillingEnabled;
     kSev *= severingEnabled;
@@ -441,6 +439,9 @@ void Parameters::verifyParameters()
             		if (zipFraction > 1.)
                 	zipFraction = 1.;
         	}
+        break;
+
+        case int_COUNT_LAST:
         break;
     }
 

--- a/src/parameters.cpp
+++ b/src/parameters.cpp
@@ -95,34 +95,34 @@ bool Parameters::writeToFile()
 	ofstream & of = system->parameterFile;
 	of << "# CorticalSim parameters\r\n";
 	of << "########## Input-Output path ########################\r\n";
-	of << "inputDir\t" << inputDir << "\r\n"; 	
-	of << "outputDir\t" << outputDir << "\r\n"; 
-	of << "newParameterReadInterval\t"<< newParameterReadInterval<< "\r\n"; 
-	of << "createSubdir\t"<< createSubdir << "\r\n"; 
-	of << "newParameterFile\t"<< newParameterFile << "\r\n"; 
-	of << "########## Dynamic parameters ##########\r\n"; 
-	of << "kSev\t"<< kSev	<< "\r\n"; 
-	of << "kCross\t"<< kCross  << "\r\n"; 
-	of << "vPlus\t"<< vPlus	<< "\r\n"; 
-	of << "vMin\t"<< vMin	<< "\r\n"; 
-	of << "vTM\t"<< vTM	<< "\r\n"; 
-	of << "kCat\t"<<  kCat 	 << "\r\n"; 
-	of << "kRes\t"<< kRes	<< "\r\n"; 
-	of << "kNuc\t"<<  kNuc 	 << "\r\n"; 
-	of << "magic_angle\t"<< magicAngle	<< "\r\n"; 
-	of << "poolDensity\t"<< poolDensity	<< "\r\n"; 
-	of << "nucleationType\t"<< nucleationType	<< "\r\n"; 
-	of << "########## Zip-IndCat-Severing events ######\r\n"; 
-	of << "treadmilling\t"<< treadmillingEnabled	<< "\r\n"; 
-	of << "ind_cat\t"<< catastrophesEnabled	       << "\r\n"; 
-	of << "cat_start_angle\t"<< catStartAngle	<< "\r\n"; 
-	of << "induced_cat_fraction\t"<< inducedCatastropheFraction	<< "\r\n"; 
-	of << "zippering\t"<< zipperingEnabled	<< "\r\n"; 
-	of << "zipFraction\t"<< zipFraction    << "\r\n"; 
-	of << "severing\t"<< severingEnabled	<< "\r\n"; 
-	of << "crossSevering\t"<< crossSeveringEnabled	<< "\r\n"; 
-	of << "crossSeveringTop\t"<< crossSeveringTop << "\r\n"; 
-	of << "crossSeveringStartAngle\t"<< crossSeveringStartAngle << "\r\n"; 
+	of << "inputDir\t" << inputDir << "\r\n";
+	of << "outputDir\t" << outputDir << "\r\n";
+	of << "newParameterReadInterval\t"<< newParameterReadInterval<< "\r\n";
+	of << "createSubdir\t"<< createSubdir << "\r\n";
+	of << "newParameterFile\t"<< newParameterFile << "\r\n";
+	of << "########## Dynamic parameters ##########\r\n";
+	of << "kSev\t"<< kSev	<< "\r\n";
+	of << "kCross\t"<< kCross  << "\r\n";
+	of << "vPlus\t"<< vPlus	<< "\r\n";
+	of << "vMin\t"<< vMin	<< "\r\n";
+	of << "vTM\t"<< vTM	<< "\r\n";
+	of << "kCat\t"<<  kCat 	 << "\r\n";
+	of << "kRes\t"<< kRes	<< "\r\n";
+	of << "kNuc\t"<<  kNuc 	 << "\r\n";
+	of << "magic_angle\t"<< magicAngle	<< "\r\n";
+	of << "poolDensity\t"<< poolDensity	<< "\r\n";
+	of << "nucleationType\t"<< nucleationType	<< "\r\n";
+	of << "########## Zip-IndCat-Severing events ######\r\n";
+	of << "treadmilling\t"<< treadmillingEnabled	<< "\r\n";
+	of << "ind_cat\t"<< catastrophesEnabled	       << "\r\n";
+	of << "cat_start_angle\t"<< catStartAngle	<< "\r\n";
+	of << "induced_cat_fraction\t"<< inducedCatastropheFraction	<< "\r\n";
+	of << "zippering\t"<< zipperingEnabled	<< "\r\n";
+	of << "zipFraction\t"<< zipFraction    << "\r\n";
+	of << "severing\t"<< severingEnabled	<< "\r\n";
+	of << "crossSevering\t"<< crossSeveringEnabled	<< "\r\n";
+	of << "crossSeveringTop\t"<< crossSeveringTop << "\r\n";
+	of << "crossSeveringStartAngle\t"<< crossSeveringStartAngle << "\r\n";
 	of << "########## Edge catastrophe specification ####\r\n";
 	map<string, double>::iterator it;
 	of << "########################\r\n";
@@ -130,33 +130,33 @@ bool Parameters::writeToFile()
 	for(it = edgCatMap.begin(); it!= edgCatMap.end(); it++)
 	of << it->first <<"\t"<< it->second  << "\r\n";
 	of << "########################\r\n";
-	of << "faceNumber\t"<< faceNumber	<< "\r\n"; 
+	of << "faceNumber\t"<< faceNumber	<< "\r\n";
 	for(it = faceCatMap.begin(); it!= faceCatMap.end(); it++)
-	of << it->first <<"\t"<< it->second  << "\r\n"; 
+	of << it->first <<"\t"<< it->second  << "\r\n";
 	of << "########################\r\n";
-	of << "edgeCatastropheSmooth\t"<< edgeCatastropheSmooth << "\r\n"; 
-	of << "edgeCatastropheEnabled\t"<< edgeCatastropheEnabled << "\r\n";  
-	of << "PPBkNucFraction\t"<< PPBkNucFraction << "\r\n"; 
-	of << "proportionalCatastrophes\t"<< proportionalCatastrophes 	 << "\r\n"; 
-	of << "########## specific conditions ###########\r\n"; 
-	of << "restrictedPool\t"<< restrictedPool 	 << "\r\n";   
-	of << "interactionType\t"<< interactionType << "\r\n"; 
-	of << "bundleType\t"<< bundleType	<< "\r\n"; 
-	of << "########## Random seed and run time #####\r\n"; 
-	of << "memoryLimit\t"<< memoryLimit	<< "\r\n"; 
-	of << "wallClockLimit\t"<< wallClockLimit	<< "\r\n"; 
-	of << "stopTime\t"<< stopTime	<< "\r\n"; 
-	of << "random_seed\t"<< seed	<< "\r\n"; 
-	of << "########## Movie select ############\r\n"; 
-	of << "movieEnabled\t"<< movieEnabled	<< "\r\n";  
-	of << "movieFrameInterval\t"<< movieFrameInterval	<< "\r\n"; 
-	of << "measurementInterval\t"<< measurementInterval	<< "\r\n"; 
-	of << "########## Display output ##########\r\n"; 
-	of << "showMesh\t"<<  showMesh 	<< "\r\n"; 
-	of << "showOutput\t"<< showOutput 	 << "\r\n"; 
-	of << "########## Geometry ################\r\n";  
-	of << "geometryScaleFactor\t"<< geometryScaleFactor 	<< "\r\n"; 
-	of << "geometry\t"<< geometry 	 << "\r\n"; 
+	of << "edgeCatastropheSmooth\t"<< edgeCatastropheSmooth << "\r\n";
+	of << "edgeCatastropheEnabled\t"<< edgeCatastropheEnabled << "\r\n";
+	of << "PPBkNucFraction\t"<< PPBkNucFraction << "\r\n";
+	of << "proportionalCatastrophes\t"<< proportionalCatastrophes 	 << "\r\n";
+	of << "########## specific conditions ###########\r\n";
+	of << "restrictedPool\t"<< restrictedPool 	 << "\r\n";
+	of << "interactionType\t"<< interactionType << "\r\n";
+	of << "bundleType\t"<< bundleType	<< "\r\n";
+	of << "########## Random seed and run time #####\r\n";
+	of << "memoryLimit\t"<< memoryLimit	<< "\r\n";
+	of << "wallClockLimit\t"<< wallClockLimit	<< "\r\n";
+	of << "stopTime\t"<< stopTime	<< "\r\n";
+	of << "random_seed\t"<< seed	<< "\r\n";
+	of << "########## Movie select ############\r\n";
+	of << "movieEnabled\t"<< movieEnabled	<< "\r\n";
+	of << "movieFrameInterval\t"<< movieFrameInterval	<< "\r\n";
+	of << "measurementInterval\t"<< measurementInterval	<< "\r\n";
+	of << "########## Display output ##########\r\n";
+	of << "showMesh\t"<<  showMesh 	<< "\r\n";
+	of << "showOutput\t"<< showOutput 	 << "\r\n";
+	of << "########## Geometry ################\r\n";
+	of << "geometryScaleFactor\t"<< geometryScaleFactor 	<< "\r\n";
+	of << "geometry\t"<< geometry 	 << "\r\n";
 
     return true;
 }
@@ -182,7 +182,7 @@ template<class T> inline void loadParamMaps(bool& recognized, ifstream& file, st
         {
             file >> target;
 	    string key = boost::lexical_cast<string>(tag);
-	    edgCatMap[key] = target; 
+	    edgCatMap[key] = target;
             recognized = true;
         }
     }
@@ -199,7 +199,7 @@ template<class T> inline void loadParamRandom(bool& recognized, ifstream& file, 
             {
                 string temp;
                 file >> temp;
-                while (temp > boost::lexical_cast<string>(ULONG_MAX)) 
+                while (temp > boost::lexical_cast<string>(ULONG_MAX))
                 {
                     cout << temp <<" Bigger than" <<boost::lexical_cast<string>(ULONG_MAX)<<endl;
                     temp = temp.substr(1);
@@ -226,7 +226,7 @@ template<class T> inline void loadParamEnumText(bool& recognized, ifstream& file
         {
             int i = 0;
             string temp;
-            file >> temp; 
+            file >> temp;
             while(i<compareCount)
             {
                 if (temp == compareList[i])
@@ -253,7 +253,7 @@ bool Parameters::readFromFile(const char* pf, bool initialRun)
         return false;
 
     ifstream parFile;
-    parFile.open(pf); 
+    parFile.open(pf);
     if (!parFile.good())
     {
         cerr << "Could not open parameter file [" << pf << "].\n";
@@ -268,7 +268,7 @@ bool Parameters::readFromFile(const char* pf, bool initialRun)
     while (parFile.good() )
     {
         parFile >> id;
-        if (!parFile.good()) 
+        if (!parFile.good())
 	break;
 
         if (id[0] == '#')
@@ -278,8 +278,8 @@ bool Parameters::readFromFile(const char* pf, bool initialRun)
             recognized = false;
 
             if (initialRun)
-            loadParamRandom(recognized, parFile, id, "random_seed", seed); 
-    
+            loadParamRandom(recognized, parFile, id, "random_seed", seed);
+
             loadParam(recognized, parFile, id, "outputDir", outputDir);
 	    loadParam(recognized, parFile, id, "inputDir", inputDir);
             loadParam(recognized, parFile, id, "createSubdir", createSubdir);
@@ -352,7 +352,7 @@ bool Parameters::readFromFile(const char* pf, bool initialRun)
             {
                 cerr << "Parameter not recognized: " << id << "\n";
             }
-            getline(parFile, id);	
+            getline(parFile, id);
         }
     }
 
@@ -425,7 +425,7 @@ void Parameters::verifyParameters()
     switch(interactionType)
     {
         // catastrophe first, need no further conditional check
-    	case int_catFirst: 
+    	case int_catFirst:
         break;
 
         // zip first needs further check
@@ -456,7 +456,7 @@ bool Parameters::calcTheoryParameters(void)
 
     switch (interactionType)
     {
-	// zippering first is requested   	
+	// zippering first is requested
 	case int_zipFirst:
 
 		// fzippering is enabled
@@ -482,9 +482,9 @@ bool Parameters::calcTheoryParameters(void)
                     		c0calc = (4.0/PI)*2.0*inducedCatastropheFraction*(1.0 - sin(csRad))/(PI - 2.0*csRad);
             		}
 
-	    		// proportional catastrophe is disabled 
+	    		// proportional catastrophe is disabled
             		else
-			c0calc = (4.0/PI)*inducedCatastropheFraction*cos(max(maRad,csRad));           		
+			c0calc = (4.0/PI)*inducedCatastropheFraction*cos(max(maRad,csRad));
         	}
 
 		// catastrophe is disabled
@@ -495,7 +495,7 @@ bool Parameters::calcTheoryParameters(void)
         	x0calc = (4.0/PI) - z0calc - c0calc;
         break;
 
-    	// catastrophe first is requested  
+    	// catastrophe first is requested
     	case int_catFirst:
 
 		// catastrophe is enabled
@@ -508,7 +508,7 @@ bool Parameters::calcTheoryParameters(void)
                 		c0calc = (4.0/PI)*2.0*inducedCatastropheFraction*(1.0-sin(temp)+(temp - csRad)*cos(temp))/(PI-2.0*csRad);
             		}
 
-			// proportional catastrophe is disabled 
+			// proportional catastrophe is disabled
             		else
                 	c0calc = (4.0/PI)*inducedCatastropheFraction*cos(max(csRad,0.));
         	}
@@ -529,9 +529,9 @@ bool Parameters::calcTheoryParameters(void)
                               		- (maRad - csRad)*cos(maRad) - sin(leftBoundary) + sin(maRad))/(PI- 2.0*csRad);
                 		}
 
-				// proportional catastrophe is disabled 
-                		else                
-                    		z0calc -= (4.0/PI)*inducedCatastropheFraction*(cos(csRad)-cos(maRad)) ;                
+				// proportional catastrophe is disabled
+                		else
+                    		z0calc -= (4.0/PI)*inducedCatastropheFraction*(cos(csRad)-cos(maRad)) ;
             		}
         	}
 
@@ -553,7 +553,7 @@ bool Parameters::calcTheoryParameters(void)
     double l0 = pow((2.0*(-vMin+vTM)*(vPlus-vTM)*(vPlus - vTM))/(kNuc*vPlus*(-vMin+vPlus)), 1./3.);
     double lavgInv = kRes/(-vMin+vTM) - kCat/(vPlus - vTM);
     double G_0 =  l0*lavgInv ;
- 
+
     if(showOutput == 1)
     {
 	    cout <<"==============================================="<<endl;

--- a/src/queue.cpp
+++ b/src/queue.cpp
@@ -57,14 +57,14 @@ DeterministicEvent DeterministicQueue::pop()
 
 void DeterministicQueue::advanceTime(double t)
 {
-        // get advanced in time 
+        // get advanced in time
 	currentBase += (system->*timeDistanceConversionFunction)(t - system->systemTime);
 	return;
 }
 
 void DeterministicQueue::storeTime(int tag)
 {
-        // store the current base time 
+        // store the current base time
 	valueCache[tag] = currentBase;
 	return;
 }
@@ -122,7 +122,7 @@ EventDescriptor::EventDescriptor(Microtubule* m, DeterministicQueue* q, double v
 
 EventDescriptor::~EventDescriptor()
 {
-	// unregister the event descriptor	
+	// unregister the event descriptor
 	mt->system->unregisterEventDescriptor(index);
 	return;
 }
@@ -156,7 +156,7 @@ void EventDescriptor::pushOnQueue(double dist, DeterministicEventType t)
 
 	type = t;
 
-        // store deterministic event into the queue 
+        // store deterministic event into the queue
 	tag = queue->pushDeterministic(queue->currentPos() + dist*distanceScaleFactor, index);
 	return;
 }

--- a/src/queue.cpp
+++ b/src/queue.cpp
@@ -1,10 +1,10 @@
 #include "corticalSimReal.h"
 
 DeterministicQueue::DeterministicQueue(System* s, double (System::*dtFunc)(double), double (System::*tdFunc)(double)) :
-		system(s),
-		distanceTimeConversionFunction(dtFunc),
-		timeDistanceConversionFunction(tdFunc),
-		currentBase(0)
+        system(s),
+        currentBase(0),
+        distanceTimeConversionFunction(dtFunc),
+        timeDistanceConversionFunction(tdFunc)
 {
 	// do not use the system pointer here, as it has not been initialized
 	valueCache[0] = 0;
@@ -94,8 +94,8 @@ EventTrackingTag DeterministicQueue::pushDeterministic(double timedist, EventDes
 }
 
 EventDescriptor::EventDescriptor(Microtubule* m, DeterministicQueue* q, double velocity) :
-		mt(m),
-		index(0),
+        index(0),
+        mt(m),
 		type(ev_none),
 		tag(-1),
 		queue(q)

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -2,33 +2,34 @@
 #include "meshImport.h"
 
 System::System(char* parFile) :
-    EventDescriptorID(0),
-    eventID(0),
-    memUsage(0),
-    totalLength(0),
+    geometry(NULL),
+    p(this),
     systemTime(0),
     systemTimeOffset(0),
+    currentTimeTag(0),
+    totalLength(0),
+    memUsage(0),
     stopSignal(false),
-    timeQueue(this, &System::identity, &System::identity),
-    vPlusQueue(this, &System::vPlusToTime, &System::timeToVPlus),
+    wallClockStartTime(time(0)),
     totalSEventCount(0),
-    totalInvalidDEventCount(0),
     totalValidDEventCount(0),
+    totalInvalidDEventCount(0),
+    totalLengthSeveringCount(0),
+    totalIntersectionSeveringCount(0),
     boundaryCrossingCount(0),
     totalZipperCount(0),
     totalCrossoverCount(0),
     totalInducedCatastropheCount(0),
-    totalLengthSeveringCount(0),
-    totalIntersectionSeveringCount(0),
     countSegments(0),
     countTrajectories(0),
     countIntersections(0),
-    dataSaved(false),
-    currentTimeTag(0),
-    wallClockStartTime(time(0)),
-    nextSnapshotEventTime(0),
+    timeQueue(this, &System::identity, &System::identity),
+    vPlusQueue(this, &System::vPlusToTime, &System::timeToVPlus),
     nextStatusEventTime(0),
-    p(this),geometry(NULL)
+    nextSnapshotEventTime(0),
+    EventDescriptorID(0),
+    eventID(0),
+    dataSaved(false)
 {
      	/// read parameters
      	p.initialize(parFile);
@@ -231,10 +232,9 @@ void System::flushAndReload(bool refreshParameterEvent)
     // recalculate total lengths to avoid drift (in DBG mode, also check for large deviations)
     double regionLength(0.);
     double systemLength(0);
-    int ridx(0);
     Trajectory* tptr(NULL);
 
-    for (ridx = 0; ridx < geometry->regions.size(); ridx++)
+    for (size_t ridx = 0; ridx < geometry->regions.size(); ridx++)
     {
         regionLength = 0;
         tptr = geometry->regions[ridx]->trajectories.first();
@@ -497,7 +497,7 @@ void System::advanceTime(double newTime)
 void System::updateAll(bool forceUpdate)
 {
     // always nice to be updated in lengths of all regions and microtubules (convenient for snapshots, etc.)
-    for (int ridx = 0; ridx < geometry->regions.size(); ridx++)
+    for (size_t ridx = 0; ridx < geometry->regions.size(); ridx++)
         geometry->regions[ridx]->updateRegionLength(forceUpdate);
 
     Microtubule* mt;
@@ -655,7 +655,8 @@ inline
 void System::handleCatastropheEvent()
 {
 
-    int tipNumber(0), totalRelevantTips(0),ridx(0),domainType(0);
+    size_t tipNumber (0), totalRelevantTips (0), ridx (0);
+    int domainType (0);
     RegionMTTipTag tipTag;
 
     double norm(0.0);
@@ -746,15 +747,19 @@ inline
 
 void System::handleRescueEvent()
 {
-    int ridx(0);
-    int tipNumber(0);
+    // TODO
+    // Fix the logic below and the types of these variables
+    // to eliminate the need for static_cast.
+    size_t ridx(0);
+    unsigned long int tipNumber (0);
+
     RegionMTTipTag tipTag;
 
     // select the number of the tip to be rescued
     tipNumber = randomGen.randInt(shrinking_mts.size() - 1);
 
     // determine the region this tip is located : binary search algorithm
-    if (tipNumber < shrinking_mts.size()/2)
+    if (tipNumber < static_cast<unsigned long long>(shrinking_mts.size()/2))
     {
         while (tipNumber >= geometry->regions[ridx]->shrinkingPlusTipList.size())
         {
@@ -824,7 +829,10 @@ void System::handleSeveringEvent()
 
 void System::randomPositionOnMicrotubule(double& randomPos, Segment*& randomSeg)
 {
-    int ridx(0);
+    // TODO
+    // Fix the logic below and the type of this variable
+    // to eliminate the need for static_cast.
+    long long ridx(0);
     // select position at which severing will take place
     double cutLength = randomGen.randDblExc(totalLength);
     // first, select relevant region. Go from both sides to reduce time.
@@ -838,7 +846,7 @@ void System::randomPositionOnMicrotubule(double& randomPos, Segment*& randomSeg)
                 break;
             cutLength -= geometry->regions[ridx]->totalLength;
             ridx++;
-            if (ridx == geometry->regions.size())
+            if (ridx == static_cast<long long>(geometry->regions.size()))
             {
                 // apparently, cutLength was *just* too long...
                 cutLength -= ZERO_CUTOFF;
@@ -855,7 +863,7 @@ void System::randomPositionOnMicrotubule(double& randomPos, Segment*& randomSeg)
     }
     else
     {
-        ridx = geometry->regions.size()-1;
+        ridx = static_cast<long long>(geometry->regions.size()-1);
         cutLength = totalLength - cutLength;
         while (true)
         {
@@ -1091,8 +1099,7 @@ void System::handleNucleationEvent()
     if (sv.region->faceTag == -1)
         return;
 
-    Segment* nucSeg(NULL);
-    double pos(0.0),posOnSeg(0.0),overrideAngle(0.0),rand(0.0),rand2(0.0),preTheta(0.0),cosTheta(0.0),temp(0.0);
+    double overrideAngle (0.0);
 
     switch (p.nucleationType)
     {
@@ -1106,7 +1113,7 @@ void System::handleNucleationEvent()
 
     sv.angle = overrideAngle;
     tv = geometry->createTrajectory(sv);
-    Microtubule* mt = growing_mts.create(this, tv);
+    growing_mts.create(this, tv);
 
     return;
 }
@@ -1237,6 +1244,9 @@ void System::handleGlobalEvent(DeterministicEvent& event)
 
     switch (event.global_type)
     {
+
+        case measure:
+            break;
     	case status:
         	if (!integrityCheck())
         	{
@@ -1344,14 +1354,16 @@ void System::handleGlobalEvent(DeterministicEvent& event)
 		for(int dTag = 0; dTag <= p.faceNumber; dTag++)
 		growingTipsReg[dTag] = 0;
 
-		for(int eno = 0; eno < geometry->regions.size(); eno++)
+		for(size_t eno = 0; eno < geometry->regions.size(); eno++)
 		{
 			if(geometry->regions[eno]->polyIntersectMark==1)
 			{
 				geometry->regions[eno]->faceTag = 1;
 
-				for(int tip =0; tip< geometry->regions[eno]->growingPlusTipList.size();tip++)
-				growingTipsReg[1]+=1;
+				for(size_t tip =0; tip< geometry->regions[eno]->growingPlusTipList.size();tip++)
+				{
+                    growingTipsReg[1]+=1;
+                }
 
 				geometry->patchArea[1]+=geometry->regions[eno]->area;
                         	geometry->RegionsIndex[1].push_back(eno);
@@ -1361,8 +1373,10 @@ void System::handleGlobalEvent(DeterministicEvent& event)
 			{
 				geometry->regions[eno]->faceTag = 2;
 
-				for(int tip =0; tip< geometry->regions[eno]->growingPlusTipList.size();tip++)
-				growingTipsReg[2]+=1;
+				for(size_t tip =0; tip< geometry->regions[eno]->growingPlusTipList.size();tip++)
+				{
+                    growingTipsReg[2]+=1;
+                }
 
 				geometry->patchArea[2]+=geometry->regions[eno]->area;
                         	geometry->RegionsIndex[2].push_back(eno);
@@ -1372,6 +1386,7 @@ void System::handleGlobalEvent(DeterministicEvent& event)
         	nextPPBEventTime = VERY_LARGE;
 
         	break;
+
     }
 
     return;

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -1453,5 +1453,3 @@ void System::makeBinomialTable(void)
             binomialTable[i][j] = factorial[i]/(factorial[j]*factorial[i-j]);
     return;
 }
-
-


### PR DESCRIPTION
- Removed unused variables.
- Fixed several initialiser lists and class declarations to ensure correct attribute initialisation order.
- Fixed several switch/case statements that were missing some of the cases.
    - NOTE: some of these need to be refactored further because they contain initialisations inside case labels, which can cause further compiler warnings.
- Fixed several comparisons involving incompatible signedness.
- Fixed two instances where comparison (`==`) was used instead of assignment (`=`). They were fairly obvious, but nevertheless further tests are needed to confirm that there are no regressions.
- Removed trailing spaces and new lines at the ends of files.