### PR TITLE
Remove the dependency on Boost

### DIFF
--- a/src/IO-analysis.cpp
+++ b/src/IO-analysis.cpp
@@ -1,3 +1,4 @@
+#include <filesystem>
 #include "corticalSimReal.h"
 
 ostream& operator<<(ostream& o, const Measurement m)
@@ -36,7 +37,7 @@ void System::initializeOutput(void)
 
         // create subdirectory with a time Tag, to isolate each data folder
         p.outputDir += "/" + p.geometry + "/outputData" + string(timeName);
-        int i = boost::filesystem::create_directories(p.outputDir.c_str());
+        int i = std::filesystem::create_directories(p.outputDir.c_str());
 
         // if the sub-directory path is invalid
         if (i)

--- a/src/meshImport.cpp
+++ b/src/meshImport.cpp
@@ -619,7 +619,7 @@ void pickup_shape(Geometry* g)
     for (it = g->system->p.edgCatMap.begin(); it != g->system->p.edgCatMap.end(); it++)
     {
         vector<string> currEdg = split(it->first, '_');
-        int edgIdx = boost::lexical_cast<int>(currEdg[1]);
+        int edgIdx{ std::stoi(currEdg[1]) };
         double edgCatVal = it->second;
         pCatList[edgIdx] = edgCatVal;
     }
@@ -634,7 +634,7 @@ void pickup_shape(Geometry* g)
     for (it = g->system->p.faceCatMap.begin(); it != g->system->p.faceCatMap.end(); it++)
     {
         vector<string> currFace = split(it->first, '_');
-        int faceIdx = boost::lexical_cast<int>(currFace[1]);
+        int faceIdx{ std::stoi(currFace[1]) };
         double faceCatVal = it->second;
         g->system->p.RegionKcatMultiplier[faceIdx] = faceCatVal;
     }

--- a/src/parameters.cpp
+++ b/src/parameters.cpp
@@ -1,3 +1,4 @@
+#include <sstream>
 #include "corticalSimReal.h"
 
 string DirectionTypeText[] = { "forward", "backward" };
@@ -191,7 +192,7 @@ bool& recognized, ifstream& file, string& id, const char* tag, T& target, map<st
         if (id == tag)
         {
             file >> target;
-            string key = boost::lexical_cast<string>(tag);
+            string key{ tag };
             edgCatMap[key] = target;
             recognized = true;
         }
@@ -202,6 +203,7 @@ bool& recognized, ifstream& file, string& id, const char* tag, T& target, map<st
 template <class T>
 inline void loadParamRandom(bool& recognized, ifstream& file, string& id, const char* tag, T& target)
 {
+    std::stringstream ss;
     if (!recognized)
     {
         if (id == tag)
@@ -210,12 +212,14 @@ inline void loadParamRandom(bool& recognized, ifstream& file, string& id, const 
             {
                 string temp;
                 file >> temp;
-                while (temp > boost::lexical_cast<string>(ULONG_MAX))
+                std::string ulong_max{ std::to_string(ULONG_MAX) };
+                while (temp > ulong_max)
                 {
-                    cout << temp << " Bigger than" << boost::lexical_cast<string>(ULONG_MAX) << endl;
+                    cout << temp << " Bigger than" << ulong_max << endl;
                     temp = temp.substr(1);
                 }
-                target = boost::lexical_cast<T>(temp);
+                ss.str(temp);
+                ss >> target;
             }
             else
             {
@@ -357,7 +361,7 @@ bool Parameters::readFromFile(const char* pf, bool initialRun)
             for (int edg = 1; edg <= edgNumber; edg++)
             {
                 double edgCatVal;
-                string edgCatType1 = "edgCat_" + boost::lexical_cast<string>(edg);
+                string edgCatType1 = "edgCat_" + std::to_string(edg);
                 char* edgCatType = new char[edgCatType1.length() + 1];
                 strcpy(edgCatType, edgCatType1.c_str());
                 loadParamMaps(recognized, parFile, id, edgCatType, edgCatVal, edgCatMap);
@@ -368,7 +372,7 @@ bool Parameters::readFromFile(const char* pf, bool initialRun)
             for (int face = 1; face <= faceNumber; face++)
             {
                 double faceCatVal;
-                string faceCatType1 = "faceCat_" + boost::lexical_cast<string>(face);
+                string faceCatType1 = "faceCat_" + std::to_string(face);
                 char* faceCatType = new char[faceCatType1.length() + 1];
                 strcpy(faceCatType, faceCatType1.c_str());
                 loadParamMaps(recognized, parFile, id, faceCatType, faceCatVal, faceCatMap);


### PR DESCRIPTION
Boost is used for:

- Filesystem access (functionality provided by `<filesystem>`).
- `lexical_cast`s (can be replaced by STL functions).
~~- Custom memory management for doubly-linked lists (can be replaced with a combination of STL `memory_resource`s and containers under `std::pmr`).~~ Postponed, requires some refactoring.