### PR TITLE
Meson build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,19 @@ sudo apt install gcc libboost-filesystem-dev libeigen3-dev meson ninja-build cma
 
     This will generate an executable file called `corticalsim3d` in the current directory (`build`).
 
+    NOTE: If you are using a very old Meson version (e.g., `<0.54.0`), you need to use `ninja` instead of `meson`, with a slightly different syntax:
+
+    ```bash
+    ninja -C build corticalsim3d
+    ```
+
+    Here, `corticalsim3d` is lowercase as it refers to the target to be built, not the `corticalsim3D` directory.
+
+
+### Known issues
+
+At present, compiling with GCC>=16 throws an error related to the allocator type in a `typedef` declaration. Please use GCC<16 or Clang until this is resolved.
+
 ## Run
 
 Run the `corticalsim3d` executable with the `corticalsim3D/config/parameters_ARRAY.txt` parameter file as the first argument:

--- a/README.md
+++ b/README.md
@@ -94,11 +94,6 @@ sudo apt install gcc libboost-filesystem-dev libeigen3-dev meson ninja-build cma
 
     Here, `corticalsim3d` is lowercase as it refers to the target to be built, not the `corticalsim3D` directory.
 
-
-### Known issues
-
-At present, compiling with GCC>=16 throws an error related to the allocator type in a `typedef` declaration. Please use GCC<16 or Clang until this is resolved.
-
 ## Run
 
 Run the `corticalsim3d` executable with the `corticalsim3D/config/parameters_ARRAY.txt` parameter file as the first argument:

--- a/README.md
+++ b/README.md
@@ -80,8 +80,10 @@ sudo apt install gcc libboost-filesystem-dev libeigen3-dev meson ninja-build cma
 
 1. Enter the build directory and compile the source:
 
+    NOTE: The possible options for the `--buildtype` switch are `plain`, `debug`, `debugoptimized` and `release`. Please check the [Meson documentation page](https://mesonbuild.com/Running-Meson.html#configuring-the-build-directory) on configuring the build directory for information about the meaning of these options. We default to `release` here.
+
     ```bash
-    meson compile -C build
+    meson compile -C build --buildtype release
     ```
 
     This will generate an executable file called `corticalsim3d` in the current directory (`build`).

--- a/meson.build
+++ b/meson.build
@@ -1,10 +1,5 @@
 project('corticalsim', 'cpp')
 
-cc = meson.get_compiler('cpp')
-if cc.get_id() == 'gcc'
-    assert(cc.version() <= '16', 'Please use GCC<16. Support for GCC>=16 is work in progress.')
-endif
-
 # Directories containing header files
 incdir = include_directories('include')
 

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,9 @@
 project('corticalsim', 'cpp')
 
-# Compiler flags
-# add_global_arguments('-O2', language : 'cpp')
+cc = meson.get_compiler('cpp')
+if cc.get_id() == 'gcc'
+    assert(cc.version() <= '16', 'Please use GCC<16. Support for GCC>=16 is work in progress.')
+endif
 
 # Directories containing header files
 incdir = include_directories('include')


### PR DESCRIPTION
Updated build instructions and Meson build file. 

The compilation currently fails with GCC>=16. A GCC version check has been added to `meson.build`. It will be removed when the Boost dependency is removed.