### PR TITLE
Removed a formatting option from `.clang-format`

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -38,7 +38,7 @@ SpaceAfterOperatorKeyword: false
 SpaceBeforeCaseColon: false
 SpaceBeforeCpp11BracedList: false
 SpaceBeforeCtorInitializerColon: false
-SpaceBeforeEnumUnderlyingTypeColon: false
+# SpaceBeforeEnumUnderlyingTypeColon: false
 SpaceBeforeInheritanceColon: false
 SpaceBeforeParens: ControlStatements
 TabWidth: 4

--- a/.clang-format
+++ b/.clang-format
@@ -38,7 +38,6 @@ SpaceAfterOperatorKeyword: false
 SpaceBeforeCaseColon: false
 SpaceBeforeCpp11BracedList: false
 SpaceBeforeCtorInitializerColon: false
-# SpaceBeforeEnumUnderlyingTypeColon: false
 SpaceBeforeInheritanceColon: false
 SpaceBeforeParens: ControlStatements
 TabWidth: 4


### PR DESCRIPTION
Versions of Clang earlier than 23 throw an error.