### PR TITLE
Removing Boost

### DIFF
--- a/include/DLList.h
+++ b/include/DLList.h
@@ -1,310 +1,78 @@
 #ifndef DLLIST_H_
 #define DLLIST_H_
-#include <boost/pool/singleton_pool.hpp>
-#include <new>
+#include <list>
+#include <array>
+#include <memory_resource>
 
-using namespace std;
+template <class T>
+using DLIter = typename std::pmr::list<T>::iterator;
 
-// DLList Class v1.0
-// Simon Tindemans, 1/4/2008
-// The DLList class provides a doubly-linked list that gets around a number of problems
-// with the STL list class:
-// 1) The STL class always copies the elements on insertion. DLList initializes them 'on the spot',
-// making it suitable for non-copyable classes.
-// 2) The STL class does not allow for conversion from data pointers to list element iterators. The
-// DLList class makes this possible, leading to easier deletion (no need to store/retrieve iterators) and
-// list traversal from within objects.
-// 3) When transferring elements (single-element splice), the STL list invalidates iterators. DLList
-// allows one to transfer elements without invalidating pointers.
-
-// The DLList list can be constructed using two types of list elements.
-// First, the DLBaseItem class should be used as a base class for the individual list
-// items. This has the advantage that the pointers to the list container elements and
-// the individual objects are the same.
-
-// The second method is using DLContainerItem objects. These objects contain an object
-// of the type that is to be stored. This has the advantage that the objects don't need
-// to be compiled for list use.
-
-// Lists of objects of type T are declared as follows:
-// DLList<T> name;  					[for DLBaseItem-derived classes]
-// DLList<DLContainerItem<T> > name;	[for other classes]
-
-template <class T, int AllocatorGranularity = 32>
+template <class T, size_t granularity = 1024>
 class DLList
 {
-  private:
+    std::array<T, granularity * sizeof(T)> buffer;
+    std::pmr::monotonic_buffer_resource mbr{ buffer.data(), buffer.size() };
+    std::pmr::synchronized_pool_resource pool{ &mbr };
+    std::pmr::list<T> list_{ &pool };
 
-    int numElements;
-    // This class keeps a pointer to both the first and the last element.
-    // This is not strictly necessary (first is enough), but this has the advantage
-    // that elements can be inserted in the back and iterated over from the front of
-    // the set. In the absence of deletions, this leads to a traversal of the elements
-    // in the order of creation - and hopefully in the order of memory allocation.
-    T* firstElement;
-    T* lastElement;
+  public:
 
-    // definitions for the Boost memory pool
-    // Currently, it uses a *non*-thread safe allocation mechanism (for speed) and a user-defined granularity
-    struct PoolTag
+    ~DLList() { removeAll(); };
+
+    inline int size() { return list_.size(); }
+
+    inline DLIter<T> begin() { return list_.begin(); }
+
+    inline DLIter<T> end() { return list_.end(); }
+
+    inline DLIter<T> cbegin() { return list_.cbegin(); }
+
+    inline DLIter<T> cend() { return list_.cend(); }
+
+    inline DLIter<T> first() { return list_.begin(); }
+
+    inline DLIter<T> last() { return std::prev(list_.end()); }
+
+    inline DLIter<T> next(DLIter<T> el) { return std::next(el); }
+
+    inline DLIter<T> previous(DLIter<T> el) { return std::prev(el); }
+
+    template <class... Params>
+    DLIter<T> create(Params&&... params)
     {
+        // Pass any parameters that T's constructors accept.
+        const auto it{ list_.emplace_back(std::forward<Params>(params)...) };
+        return it;
     };
 
-    typedef boost::singleton_pool<PoolTag,
-                                  sizeof(T),
-                                  boost::default_user_allocator_new_delete,
-                                  boost::details::pool::null_mutex,
-                                  AllocatorGranularity>
-    MemPool;
-    void unlinkElement(T*);
-    T* linkElement(T*);
-
-  public:
-
-    DLList():
-        numElements(0),
-        firstElement(NULL),
-        lastElement(NULL) {};
-    ~DLList();
-
-    inline int size() { return numElements; }
-
-    inline T* first() { return firstElement; }
-
-    inline T* last() { return lastElement; }
-
-    inline T* next(T* el) { return el->nextElement; }
-
-    inline T* previous(T* el) { return el->previousElement; }
-
-    T* create();
-    template <class Q>
-    T* create(Q);
-    template <class Q, class R>
-    T* create(Q, R);
-    template <class Q, class R, class S>
-    T* create(Q, R, S);
-    void remove(T*);
-    void removeAll();
-    void import(DLList<T, AllocatorGranularity>&, T*);
-    void importSet(DLList<T, AllocatorGranularity>&, T*, T*);
-};
-
-template <class T, int i>
-DLList<T, i>::~DLList()
-{
-    removeAll();
-    return;
-}
-
-template <class T, int i>
-void DLList<T, i>::removeAll()
-{
-    while (firstElement != NULL)
+    DLIter<T> remove(DLIter<T> element)
     {
-        remove(firstElement);
-    }
-}
+        // Removes a single element.
+        // A check is performed to see if there are any elements in the list.
+        // Returns the end iterator if the removed element was the last one,
+        // otherwise it returns the element *after* the one that was removed.
+        return element == list_.end() ? list_.end() : list_.erase(element);
+    };
 
-template <class T, int i>
-inline T* DLList<T, i>::linkElement(T* newElement)
-// Inserts a new element into the linked list.
-// Insertion takes place at the back of the list for memory-traversal speed considerations.
-{
-    numElements++;
-    newElement->previousElement = lastElement;
-    newElement->nextElement = NULL;
-    if (lastElement != NULL)
+    void removeAll() { list_.clear(); };
+
+    DLIter<T> import(const DLList<T>& oldList, DLIter<T> element)
     {
-        lastElement->nextElement = newElement;
-    }
-    else // if list was empty
+        // Import a sequence of elements.
+        auto it{ list_.splice(element) };
+        oldList.list_.erase(element);
+        return it;
+    };
+
+    void importSet(const DLList<T>& oldList, DLIter<T> firstElement, DLIter<T> lastElement)
     {
-        firstElement = newElement;
-    }
-    lastElement = newElement;
-    return newElement;
-}
-
-template <class T, int i>
-inline void DLList<T, i>::unlinkElement(T* element)
-// Removes an element from the linked list.
-{
-    numElements--;
-    if (element == firstElement)
-    {
-        firstElement = element->nextElement;
-    }
-    if (element == lastElement)
-    {
-        lastElement = element->previousElement;
-    }
-    if (element->nextElement != NULL)
-    {
-        element->nextElement->previousElement = element->previousElement;
-    }
-    if (element->previousElement != NULL)
-    {
-        element->previousElement->nextElement = element->nextElement;
-    }
-    return;
-}
-
-template <class T, int i>
-inline void DLList<T, i>::remove(T* element)
-// Removes a single element. No checking is performed on the pointer.
-{
-    unlinkElement(element);
-    element->~T();
-    MemPool::free(element);
-    return;
-}
-
-/// The following functions create a new element from the heap and insert it into the linked list.
-// These differ only in the number of arguments that is passed to the constructor.
-template <class T, int i>
-inline T* DLList<T, i>::create()
-{
-    T* newElement = new (MemPool::malloc()) T();
-    return linkElement(newElement);
-}
-
-template <class T, int i>
-template <class Q>
-inline T* DLList<T, i>::create(Q par1)
-{
-    T* newElement = new (MemPool::malloc()) T(par1);
-    return linkElement(newElement);
-}
-
-template <class T, int i>
-template <class Q, class R>
-inline T* DLList<T, i>::create(Q par1, R par2)
-{
-    T* newElement = new (MemPool::malloc()) T(par1, par2);
-    return linkElement(newElement);
-}
-
-template <class T, int i>
-template <class Q, class R, class S>
-inline T* DLList<T, i>::create(Q par1, R par2, S par3)
-{
-    T* newElement = new (MemPool::malloc()) T(par1, par2, par3);
-    return linkElement(newElement);
-}
-
-template <class T, int i>
-// This functions transfers 'element' from 'oldList' to this list.
-inline void DLList<T, i>::import(DLList<T, i>& oldList, T* element)
-{
-    oldList.unlinkElement(element);
-    linkElement(element);
-    return;
-}
-
-template <class T, int i>
-inline void DLList<T, i>::importSet(DLList<T, i>& oldList, T* firstElement, T* lastElement)
-// This functions transfers a number of elements from 'oldList' to this list.
-// WARNING: not efficient at all!
-{
-    T* current = firstElement;
-    T* temp;
-    while (current != NULL)
-    {
-        temp = current;
-        current = current->next();
-        import(oldList, temp);
-        if (temp == lastElement)
+        // This is very inefficient, but it should work as a first approximation.
+        // Ideally, this method should use `std::pmr::list::splice()`.
+        for (auto current = firstElement; current != lastElement; ++current)
         {
-            break;
+            import(oldList, current);
         }
-    }
-    return;
-}
-
-template <class T>
-// this list item should be used as a base class [type 1 - see above]
-class DLBaseItem
-{
-  public:
-
-    template <class X, int i>
-    friend class DLList;
-
-  private:
-
-    T* nextElement;
-    T* previousElement;
-
-  protected:
-
-    // make sure that this cannot be deleted...
-    virtual ~DLBaseItem() {};
-
-  public:
-
-    inline T* next() { return nextElement; }
-
-    inline T* previous() { return previousElement; }
-};
-
-template <class T>
-// This is a stand-alone version of the list item. It contains a data object of type T
-// and functions to convert between the pointers to the data and pointers to the element
-// itself
-class DLContainerItem
-{
-    friend class DLList<DLContainerItem<T>>;
-
-  private:
-
-    DLContainerItem<T>* nextElement;
-    DLContainerItem<T>* previousElement;
-
-  protected:
-
-    // make sure that items can only be deleted by DLList<DLContainerItem<T> > objects
-    virtual ~DLContainerItem() {};
-
-  public:
-
-    T data;
-
-    inline DLContainerItem<T>* next() { return nextElement; }
-
-    inline DLContainerItem<T>* previous() { return previousElement; }
-
-    inline T* dataPtr() { return &data; }
-
-    // very ugly hack, but it works [tested with G++ & icc]. For a data object with an unknown location in a known list,
-    // call list->first()->containerPtr(data*); for some reason, I need to convert to void* and char*... This should
-    // have been done in a better way...
-    inline DLContainerItem<T>* containerPtr(T* dPtr)
-    {
-        return static_cast<DLContainerItem<T>*>(static_cast<void*>(
-        static_cast<short*>(static_cast<void*>(dPtr))
-        - (static_cast<short*>(static_cast<void*>(&data)) - static_cast<short*>(static_cast<void*>(this)))));
-    }
-
-    DLContainerItem() {}
-
-    template <class Q>
-    inline DLContainerItem(Q par1):
-        data(par1)
-    {
-    }
-
-    template <class Q, class R>
-    inline DLContainerItem(Q par1, R par2):
-        data(par1, par2)
-    {
-    }
-
-    template <class Q, class R, class S>
-    inline DLContainerItem(Q par1, R par2, S par3):
-        data(par1, par2, par3)
-    {
-    }
+    };
 };
 
 #endif // DLLIST_H_

--- a/include/corticalSimReal.h
+++ b/include/corticalSimReal.h
@@ -42,9 +42,6 @@
 #include <list>
 #include <map>
 #include <queue>
-#include <boost/pool/pool_alloc.hpp>
-#include <boost/lexical_cast.hpp>
-#include <boost/filesystem.hpp>
 #include <string>
 #include <cstring>
 #include <cmath>
@@ -192,10 +189,9 @@ class Intersection;
 class OccupiedIntersection;
 #endif
 
-typedef multimap<double,
-                 Intersection,
-                 std::less<double>,
-                 boost::fast_pool_allocator<std::pair<double, Intersection>>>::iterator IntersectionItr;
+using IntersectionItr = multimap<double, Intersection>::iterator;
+using SegmentItr = DLIter<Segment>;
+using MTItr = DLIter<Microtubule>;
 typedef int EventDescriptorIndex;
 typedef int EventTrackingTag;
 typedef list<Segment*>::iterator TrjSegmentTag;
@@ -389,7 +385,7 @@ class PointATedge
     }
 };
 
-class Trajectory: public DLBaseItem<Trajectory>
+class Trajectory
 // the trajectory is the basic geometrical object. Tips and segments associate
 // with a trajectory and move/lie alongside it. Trajectory intersections
 // determine the collision points
@@ -423,8 +419,7 @@ class Trajectory: public DLBaseItem<Trajectory>
     // regular catastrophe value at the trajectory far end
     double nextTrpCat;
 
-    multimap<double, Intersection, std::less<double>, boost::fast_pool_allocator<std::pair<double, Intersection>>>
-    intersections;
+    multimap<double, IntersectionItr> intersections;
 
     // sorted list of all intersections
     IntersectionItr wallEnd()
@@ -440,6 +435,7 @@ class Trajectory: public DLBaseItem<Trajectory>
         return intersections.begin();
     }
 
+    Trajectory();
     explicit Trajectory(SurfaceVector, vector<PointATedge>, double);
     ~Trajectory();
 
@@ -453,10 +449,10 @@ class Trajectory: public DLBaseItem<Trajectory>
     void conditionalRemove();
 
     // list of pointers to associated segments
-    list<Segment*> segments;
+    list<SegmentItr> segments;
 
     // inserts a segment into the list
-    TrjSegmentTag insertSegment(Segment*);
+    TrjSegmentTag insertSegment(SegmentItr);
 
     // removes a segment from the list
     void removeSegment(TrjSegmentTag);
@@ -878,7 +874,7 @@ class MTTip
     MTTip& operator=(const MTTip&);
 };
 
-class Segment: public DLBaseItem<Segment>
+class Segment
 {
   public:
 
@@ -896,6 +892,7 @@ class Segment: public DLBaseItem<Segment>
 
     // constructs a segment as part of a microtubule at a specified vector
     // location
+    Segment();
     Segment(Microtubule*, TrajectoryVector&);
 
     ~Segment();
@@ -907,7 +904,7 @@ class Segment: public DLBaseItem<Segment>
     bool crossesIntersection(IntersectionItr& is);
 };
 
-class Microtubule: public DLBaseItem<Microtubule>
+class Microtubule
 {
   public:
 
@@ -1208,6 +1205,11 @@ class System
     void performMeasurement();
     void writeMeasurementsToFile(int = 0);
     void closeFiles();
+
+    // Methods ported from the Microtubule class
+    void catastrophe(const MTTip&);
+    void rescue(const MTTip&);
+    void wall(const MTTip&);
 
 #ifdef CROSS_SEV
     // removes pointers from is and its mirror

--- a/src/IO-analysis.cpp
+++ b/src/IO-analysis.cpp
@@ -122,19 +122,15 @@ void System::performMeasurement(void)
     m.shrinkingNumber = shrinking_mts.size();
 
     int segmentCount = 0;
-    Microtubule* mt;
 
-    mt = growing_mts.first();
-    while (mt != NULL)
+    for (auto mt = growing_mts.begin(); mt != growing_mts.end(); ++mt)
     {
         segmentCount += mt->segments.size();
-        mt = mt->next();
     }
-    mt = shrinking_mts.first();
-    while (mt != NULL)
+
+    for (auto mt = shrinking_mts.begin(); mt != shrinking_mts.end(); ++mt)
     {
         segmentCount += mt->segments.size();
-        mt = mt->next();
     }
 
     // total number of segments

--- a/src/geometry-generic.cpp
+++ b/src/geometry-generic.cpp
@@ -400,6 +400,31 @@ void Region::unregisterFromRegion(RegionMTTipTag tag, TipType tiptype, MTType mt
     return;
 }
 
+Trajectory::Trajectory():
+    base({}),
+    length(0.0),
+    prevTr(0, ::forward, NULL),
+    nextTr(0, ::forward, NULL),
+    prevTrCosAngle(1.0),
+    nextTrCosAngle(1.0)
+{
+#ifdef DBG_GEOMETRY
+    cout << "DBG/GEOMETRY: Trajectory created\n";
+#endif
+
+    // assign end points of the trajectory
+    for (int i = 0; i < 2; i++)
+    {
+        endPoint.push_back(endP[i]);
+    }
+
+    // increase total number of trajectories in the geometry
+    base.region->geometry->system->countTrajectories++;
+
+    // initialize the intersection list of the trajectory
+    intersections.insert(pair<double, Intersection>(-1.0, Intersection()));
+}
+
 Trajectory::Trajectory(SurfaceVector baseVec, vector<PointATedge> endP, double l):
     base(baseVec),
     length(l),
@@ -423,15 +448,12 @@ Trajectory::Trajectory(SurfaceVector baseVec, vector<PointATedge> endP, double l
 
     // initialize the intersection list of the trajectory
     intersections.insert(pair<double, Intersection>(-1.0, Intersection()));
-
-    return;
 }
 
 Trajectory::~Trajectory()
 {
     // decrease total number of trajectories in the geometry
     base.region->geometry->system->countTrajectories--;
-    return;
 }
 
 bool Trajectory::integrityCheck()

--- a/src/inline.cpp
+++ b/src/inline.cpp
@@ -1,3 +1,4 @@
+#include <iterator>
 #include <cstddef>
 
 #ifndef NO_INLINE
@@ -294,13 +295,13 @@ inline
 double Microtubule::length()
 {
     double temp = 0.0;
-    Segment* seg = segments.first();
+    // Segment* seg = segments.first();
+    // std::list<SegmentItr> seg{ segments.first() };
 
     // calculate total length of a MT
-    while (seg != NULL)
+    for (auto seg = segments.begin(); seg != segments.end(); ++seg)
     {
         temp += seg->length();
-        seg = seg->next();
     }
     return temp;
 }
@@ -333,8 +334,10 @@ void Microtubule::updateLength(bool forceUpdate)
 #endif
 
     // move the position of the active (first and last) segment end
-    segments.last()->end += plus.event.queue->progression(previousUpdateTag) * plus.dir * plus.velocity;
-    segments.first()->start += minus.event.queue->progression(previousUpdateTag) * minus.dir * minus.velocity;
+    segments.last()->end
+    += plus.event.queue->progression(previousUpdateTag) * static_cast<int>(plus.dir) * plus.velocity;
+    segments.first()->start
+    += minus.event.queue->progression(previousUpdateTag) * static_cast<int>(minus.dir) * minus.velocity;
 
     previousUpdateTag = system->currentTimeTag;
 

--- a/src/microtubule.cpp
+++ b/src/microtubule.cpp
@@ -138,103 +138,103 @@ void Microtubule::handleEvent(const EventDescriptor* ei)
     return;
 }
 
-void Microtubule::catastrophe()
-{
-#ifdef DBG_MTS
-    cout << "DBG/MTS: Microtubule::catastrophe() called.\n";
-#endif
+// void Microtubule::catastrophe()
+// {
+// #ifdef DBG_MTS
+//     cout << "DBG/MTS: Microtubule::catastrophe() called.\n";
+// #endif
 
-#ifdef DBG_EXTRA_CHECK
-    if (type != mt_growing)
-    {
-        cout << "ERROR: catastrophe called for non-growing MT\n";
-        exit(-1);
-    }
-#endif
+// #ifdef DBG_EXTRA_CHECK
+//     if (type != mt_growing)
+//     {
+//         cout << "ERROR: catastrophe called for non-growing MT\n";
+//         exit(-1);
+//     }
+// #endif
 
-    // update MT length
-    updateLength();
+//     // update MT length
+//     updateLength();
 
-    // growing MT will become shrinking MT, hence unregister the tip from growing-plus-tip list of this region
-    plus.trajectory->base.region->unregisterFromRegion(plus.regionTag, t_plus, mt_growing);
+//     // growing MT will become shrinking MT, hence unregister the tip from growing-plus-tip list of this region
+//     plus.trajectory->base.region->unregisterFromRegion(plus.regionTag, t_plus, mt_growing);
 
-    // now, this is shrinking MT
-    type = mt_shrinking;
+//     // now, this is shrinking MT
+//     type = mt_shrinking;
 
-    // growing MT will become shrinking MT, hence register the tip on shrinking-plus-tip list of this region
-    plus.regionTag = plus.trajectory->base.region->registerOnRegion(&plus, t_plus, mt_shrinking);
+//     // growing MT will become shrinking MT, hence register the tip on shrinking-plus-tip list of this region
+//     plus.regionTag = plus.trajectory->base.region->registerOnRegion(&plus, t_plus, mt_shrinking);
 
-    // replace plus velocity by minus velocity
-    plus.velocity = system->p.vMin;
+//     // replace plus velocity by minus velocity
+//     plus.velocity = system->p.vMin;
 
-    //
-    plus.event.reinitialize(&(system->timeQueue), system->p.vMin);
+//     //
+//     plus.event.reinitialize(&(system->timeQueue), system->p.vMin);
 
-    // import the growing MT as shrinking MT
-    system->shrinking_mts.import(system->growing_mts, this);
+//     // import the growing MT as shrinking MT
+//     system->shrinking_mts.import(system->growing_mts, this);
 
-    if (system->p.vMin < 0)
-    {
-        // velocity has changed sign, select a new event
-        plus.advanceIntersection();
-    }
+//     if (system->p.vMin < 0)
+//     {
+//         // velocity has changed sign, select a new event
+//         plus.advanceIntersection();
+//     }
 
-    // schedule next event, (if this is triggered by a collision, and vMin > 0, increase occupancy)
-    plus.determineEvent();
+//     // schedule next event, (if this is triggered by a collision, and vMin > 0, increase occupancy)
+//     plus.determineEvent();
 
-    // check possibility of a disappear event
-    setDisappearEvent();
+//     // check possibility of a disappear event
+//     setDisappearEvent();
 
-    return;
-}
+//     return;
+// }
 
-void Microtubule::rescue()
-{
-#ifdef DBG_MTS
-    cout << "DBG/MTS: Microtubule::rescue() called.\n";
-#endif
+// void Microtubule::rescue()
+// {
+// #ifdef DBG_MTS
+//     cout << "DBG/MTS: Microtubule::rescue() called.\n";
+// #endif
 
-#ifdef DBG_EXTRA_CHECK
-    if (type != mt_shrinking)
-    {
-        cout << "ERROR: rescue called for non-shrinking MT\n";
-        exit(-1);
-    }
-#endif
+// #ifdef DBG_EXTRA_CHECK
+//     if (type != mt_shrinking)
+//     {
+//         cout << "ERROR: rescue called for non-shrinking MT\n";
+//         exit(-1);
+//     }
+// #endif
 
-    updateLength();
+//     updateLength();
 
-    // shrinking MT will become growing  MT, hence unregister the tip from shrinking-plus-tip list of this region
-    plus.trajectory->base.region->unregisterFromRegion(plus.regionTag, t_plus, mt_shrinking);
+//     // shrinking MT will become growing  MT, hence unregister the tip from shrinking-plus-tip list of this region
+//     plus.trajectory->base.region->unregisterFromRegion(plus.regionTag, t_plus, mt_shrinking);
 
-    // now, this is growing MT
-    type = mt_growing;
+//     // now, this is growing MT
+//     type = mt_growing;
 
-    // shrinking MT will become growing MT, hence register the tip on growing-plus-tip list of this region
-    plus.regionTag = plus.trajectory->base.region->registerOnRegion(&plus, t_plus, mt_growing);
+//     // shrinking MT will become growing MT, hence register the tip on growing-plus-tip list of this region
+//     plus.regionTag = plus.trajectory->base.region->registerOnRegion(&plus, t_plus, mt_growing);
 
-    // replace minue velocity by plus velocity
-    plus.velocity = system->p.vPlus;
+//     // replace minue velocity by plus velocity
+//     plus.velocity = system->p.vPlus;
 
-    plus.event.reinitialize(&(system->vPlusQueue), system->p.vPlus);
+//     plus.event.reinitialize(&(system->vPlusQueue), system->p.vPlus);
 
-    // import the shrinking MT as growing MT
-    system->growing_mts.import(system->shrinking_mts, this);
+//     // import the shrinking MT as growing MT
+//     system->growing_mts.import(system->shrinking_mts, this);
 
-    if (system->p.vMin < 0)
-    {
-        // velocity has changed sign, need to select a new event
-        plus.advanceIntersection();
-    }
+//     if (system->p.vMin < 0)
+//     {
+//         // velocity has changed sign, need to select a new event
+//         plus.advanceIntersection();
+//     }
 
-    // schedule next event
-    plus.determineEvent();
+//     // schedule next event
+//     plus.determineEvent();
 
-    // check possibility of a disappear event
-    setDisappearEvent();
+//     // check possibility of a disappear event
+//     setDisappearEvent();
 
-    return;
-}
+//     return;
+// }
 
 void Microtubule::sever(Segment* cutSeg, double cutPos)
 {
@@ -274,7 +274,7 @@ void Microtubule::severAtCross(IntersectionItr is, Segment* cutSeg)
 void Microtubule::splitSegmentAtTrajPos(double cutPos, Segment* cutSeg)
 {
     // used in sever and severAtCross
-    Microtubule* newMT(NULL);
+    MTItr newMT;
     TrajectoryVector tv;
 
     tv.trajectory = cutSeg->trajectory;
@@ -298,8 +298,8 @@ void Microtubule::splitSegmentAtTrajPos(double cutPos, Segment* cutSeg)
     newMT->segments.first()->endItr = cutSeg->endItr;
     newMT->segments.first()->nucleationTime = cutSeg->nucleationTime;
     newMT->segments.importSet(segments, cutSeg->next(), segments.last());
-    Segment* tempSeg = newMT->segments.first()->next();
-    while (tempSeg != NULL)
+    auto tempSeg{newMT->segments.first()->next()};
+    while (tempSeg != segments.end())
     {
         tempSeg->mt = newMT;
         tempSeg = tempSeg->next();
@@ -387,107 +387,107 @@ void Microtubule::translatePositionMT2Segment(double& cutPos, Segment*& cutSeg)
     return;
 }
 
-void Microtubule::wall()
-{
-    // only for plus end
+// void Microtubule::wall()
+// {
+//     // only for plus end
 
-    TrajectoryVector tv;
+//     TrajectoryVector tv;
 
-    // set position of the plus end equal to the event position, to mitigate the effect of cumulating addition errors
-    segments.last()->end = plus.nextEventPos;
-    tv = plus.trajectory->nextTrajectory(plus.dir);
+//     // set position of the plus end equal to the event position, to mitigate the effect of cumulating addition errors
+//     segments.last()->end = plus.nextEventPos;
+//     tv = plus.trajectory->nextTrajectory(plus.dir);
 
-    // next trajectory on 'forbidden zone', leads catastrophe
-    if (tv.trajectory->base.region->faceTag == -1)
-    {
-        tv.trajectory->conditionalRemove();
-        catastrophe();
+//     // next trajectory on 'forbidden zone', leads catastrophe
+//     if (tv.trajectory->base.region->faceTag == -1)
+//     {
+//         tv.trajectory->conditionalRemove();
+//         catastrophe();
 
-        // no wall crossing
-        return;
-    }
+//         // no wall crossing
+//         return;
+//     }
 
-    // edge catastrophe enabled
-    if (system->p.edgeCatastropheEnabled)
-    {
-        double cosAngle = (plus.dir == ::forward) ? plus.trajectory->nextTrCosAngle : plus.trajectory->prevTrCosAngle;
+//     // edge catastrophe enabled
+//     if (system->p.edgeCatastropheEnabled)
+//     {
+//         double cosAngle = (plus.dir == ::forward) ? plus.trajectory->nextTrCosAngle : plus.trajectory->prevTrCosAngle;
 
-        // MT is moving non-parallel to the edege
-        if ((1.0 - cosAngle) > ZERO_CUTOFF)
-        {
-            double pCat(0.0);
+//         // MT is moving non-parallel to the edege
+//         if ((1.0 - cosAngle) > ZERO_CUTOFF)
+//         {
+//             double pCat(0.0);
 
-            // for sharp edged cube
-            if (system->p.geometry == "cubeReal")
-            {
-                if (abs(plus.trajectory->base.region->faceTag - tv.trajectory->base.region->faceTag) > 0)
-                {
-                    if (abs(plus.trajectory->base.region->faceTag - tv.trajectory->base.region->faceTag) > 1)
-                    {
-                        pCat = system->p.pCatSpecialEdgeMax;
-                    }
+//             // for sharp edged cube
+//             if (system->p.geometry == "cubeReal")
+//             {
+//                 if (abs(plus.trajectory->base.region->faceTag - tv.trajectory->base.region->faceTag) > 0)
+//                 {
+//                     if (abs(plus.trajectory->base.region->faceTag - tv.trajectory->base.region->faceTag) > 1)
+//                     {
+//                         pCat = system->p.pCatSpecialEdgeMax;
+//                     }
 
-                    else
-                    {
-                        pCat = system->p.pCatRegularEdgeMax;
-                    }
-                }
-            }
+//                     else
+//                     {
+//                         pCat = system->p.pCatRegularEdgeMax;
+//                     }
+//                 }
+//             }
 
-            // other
-            else
-            {
-                pCat = (plus.dir == ::forward) ? plus.trajectory->nextTrpCat : plus.trajectory->prevTrpCat;
-            }
+//             // other
+//             else
+//             {
+//                 pCat = (plus.dir == ::forward) ? plus.trajectory->nextTrpCat : plus.trajectory->prevTrpCat;
+//             }
 
-            // when smooth catastrophe is enabled
-            if (system->p.edgeCatastropheSmooth)
-            {
-                pCat *= (1.0 - cosAngle);
-            }
+//             // when smooth catastrophe is enabled
+//             if (system->p.edgeCatastropheSmooth)
+//             {
+//                 pCat *= (1.0 - cosAngle);
+//             }
 
-            // apply catastrophe
-            if (system->randomGen.rand() <= pCat)
-            {
-                tv.trajectory->conditionalRemove();
-                catastrophe();
+//             // apply catastrophe
+//             if (system->randomGen.rand() <= pCat)
+//             {
+//                 tv.trajectory->conditionalRemove();
+//                 catastrophe();
 
-                // no wall crossing
-                return;
-            }
-        }
-    }
+//                 // no wall crossing
+//                 return;
+//             }
+//         }
+//     }
 
-    // update boundarty crossing count
-    system->boundaryCrossingCount++;
+//     // update boundarty crossing count
+//     system->boundaryCrossingCount++;
 
-#ifdef DBG_ASSERT
-    if (segments.last()->endItr != plus.nextCollision)
-    {
-        cerr << "DBG/ASSERT: nextCollision does not match with endItr upon entering wall event.\n";
-    }
-#endif
+// #ifdef DBG_ASSERT
+//     if (segments.last()->endItr != plus.nextCollision)
+//     {
+//         cerr << "DBG/ASSERT: nextCollision does not match with endItr upon entering wall event.\n";
+//     }
+// #endif
 
-    // wall crossing
-    segments.last()->endItr = plus.nextCollision;
+//     // wall crossing
+//     segments.last()->endItr = plus.nextCollision;
 
-    // create a new segment
-    segments.create(this, tv);
-    segments.last()->startItr = tv.dir == ::forward ? tv.trajectory->wallBegin() : tv.trajectory->wallEnd();
+//     // create a new segment
+//     segments.create(this, tv);
+//     segments.last()->startItr = tv.dir == ::forward ? tv.trajectory->wallBegin() : tv.trajectory->wallEnd();
 
-    // switch trajectory
-    plus.switchTrajectory(
-    tv.trajectory, tv.dir, tv.dir == ::forward ? tv.trajectory->wallBegin() : tv.trajectory->wallEnd());
+//     // switch trajectory
+//     plus.switchTrajectory(
+//     tv.trajectory, tv.dir, tv.dir == ::forward ? tv.trajectory->wallBegin() : tv.trajectory->wallEnd());
 
-    if (segments.size() == 2)
-    {
-        // MT with two segment of zero (=0) length, consider possibilty of a disappear event
-        minus.determineEvent();
-        setDisappearEvent();
-    }
+//     if (segments.size() == 2)
+//     {
+//         // MT with two segment of zero (=0) length, consider possibilty of a disappear event
+//         minus.determineEvent();
+//         setDisappearEvent();
+//     }
 
-    return;
-}
+//     return;
+// }
 
 void Microtubule::collision()
 {

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -78,17 +78,13 @@ System::System(char* parFile):
         timeQueue.pushGlobal(p.newParameterReadInterval, parameter_change);
         nextParameterEventTime = p.newParameterReadInterval;
     }
-
-    return;
 }
 
 System::~System()
 {
-    // destroy all MTs
+    // Destroy all MTs
     growing_mts.removeAll();
     shrinking_mts.removeAll();
-
-    return;
 }
 
 void System::run(double simTime, string& cS, string& mS)
@@ -783,7 +779,7 @@ void System::handleCatastropheEvent()
     }
     else
     {
-        tipTag = --(geometry->regions[ridx]->growingPlusTipList.end());
+        tipTag = std::prev(geometry->regions[ridx]->growingPlusTipList.end());
         while (tipNumber < geometry->regions[ridx]->growingPlusTipList.size() - 1)
         {
             tipTag--;
@@ -849,7 +845,7 @@ void System::handleRescueEvent()
     }
     else
     {
-        tipTag = --(geometry->regions[ridx]->shrinkingPlusTipList.end());
+        tipTag = geometry->regions[ridx]->shrinkingPlusTipList.back();
         while (tipNumber < geometry->regions[ridx]->shrinkingPlusTipList.size() - 1)
         {
             tipTag--;
@@ -1590,4 +1586,202 @@ void System::makeBinomialTable(void)
         }
     }
     return;
+}
+
+void System::catastrophe(const MTItr& mti)
+{
+#ifdef DBG_MTS
+    cout << "DBG/MTS: System::catastrophe() called.\n";
+#endif
+
+#ifdef DBG_EXTRA_CHECK
+    if (mti->type != mt_growing)
+    {
+        cout << "ERROR: catastrophe called for non-growing MT\n";
+        exit(-1);
+    }
+#endif
+
+    // update MT length
+    mti->updateLength();
+
+    // growing MT will become shrinking MT, hence unregister the tip from growing-plus-tip list of this region
+    mti->plus.trajectory->base.region->unregisterFromRegion(mti->plus.regionTag, t_plus, mt_growing);
+
+    // now, this is shrinking MT
+    mti->type = mt_shrinking;
+
+    // growing MT will become shrinking MT, hence register the tip on shrinking-plus-tip list of this region
+    mti->plus.regionTag = mti->plus.trajectory->base.region->registerOnRegion(&(mti->plus), t_plus, mt_shrinking);
+
+    // replace plus velocity by minus velocity
+    mti->plus.velocity = p.vMin;
+
+    //
+    mti->plus.event.reinitialize(&timeQueue, p.vMin);
+
+    // import the growing MT as shrinking MT
+    shrinking_mts.import(growing_mts, mti);
+
+    if (p.vMin < 0)
+    {
+        // velocity has changed sign, select a new event
+        mti->plus.advanceIntersection();
+    }
+
+    // schedule next event, (if this is triggered by a collision, and vMin > 0, increase occupancy)
+    mti->plus.determineEvent();
+
+    // check possibility of a disappear event
+    mti->setDisappearEvent();
+}
+
+void System::rescue(const MTTip& mti)
+{
+#ifdef DBG_MTS
+    cout << "DBG/MTS: System::rescue() called.\n";
+#endif
+
+#ifdef DBG_EXTRA_CHECK
+    if (mti->type != mt_shrinking)
+    {
+        cout << "ERROR: rescue called for non-shrinking MT\n";
+        exit(-1);
+    }
+#endif
+
+    mti->updateLength();
+
+    // shrinking MT will become growing  MT, hence unregister the tip from shrinking-plus-tip list of this region
+    mti->plus.trajectory->base.region->unregisterFromRegion(mti->plus.regionTag, t_plus, mt_shrinking);
+
+    // now, this is growing MT
+    mti->type = mt_growing;
+
+    // shrinking MT will become growing MT, hence register the tip on growing-plus-tip list of this region
+    mti->plus.regionTag = mti->plus.trajectory->base.region->registerOnRegion(&(mti->plus), t_plus, mt_growing);
+
+    // replace minue velocity by plus velocity
+    mti->plus.velocity = p.vPlus;
+
+    mti->plus.event.reinitialize(&vPlusQueue, p.vPlus);
+
+    // import the shrinking MT as growing MT
+    growing_mts.import(shrinking_mts, mti);
+
+    if (p.vMin < 0)
+    {
+        // velocity has changed sign, need to select a new event
+        mti->plus.advanceIntersection();
+    }
+
+    // schedule next event
+    mti->plus.determineEvent();
+
+    // check possibility of a disappear event
+    mti->setDisappearEvent();
+
+    return;
+}
+
+void System::wall(const MTItr& mti)
+{
+    // only for plus end
+
+    TrajectoryVector tv;
+
+    // set position of the plus end equal to the event position, to mitigate the effect of cumulating addition errors
+    segments.last()->end = plus.nextEventPos;
+    tv = plus.trajectory->nextTrajectory(plus.dir);
+
+    // next trajectory on 'forbidden zone', leads catastrophe
+    if (tv.trajectory->base.region->faceTag == -1)
+    {
+        tv.trajectory->conditionalRemove();
+        catastrophe(mti);
+
+        // no wall crossing
+        return;
+    }
+
+    // edge catastrophe enabled
+    if (p.edgeCatastropheEnabled)
+    {
+        double cosAngle
+        = (mti->plus.dir == ::forward) ? mti->plus.trajectory->nextTrCosAngle : mti->plus.trajectory->prevTrCosAngle;
+
+        // MT is moving non-parallel to the edege
+        if ((1.0 - cosAngle) > ZERO_CUTOFF)
+        {
+            double pCat(0.0);
+
+            // for sharp edged cube
+            if (p.geometry == "cubeReal")
+            {
+                if (abs(mti->plus.trajectory->base.region->faceTag - tv.trajectory->base.region->faceTag) > 0)
+                {
+                    if (abs(mti->plus.trajectory->base.region->faceTag - tv.trajectory->base.region->faceTag) > 1)
+                    {
+                        pCat = p.pCatSpecialEdgeMax;
+                    }
+
+                    else
+                    {
+                        pCat = p.pCatRegularEdgeMax;
+                    }
+                }
+            }
+
+            // other
+            else
+            {
+                pCat
+                = (mti->plus.dir == ::forward) ? mti->plus.trajectory->nextTrpCat : mti->plus.trajectory->prevTrpCat;
+            }
+
+            // when smooth catastrophe is enabled
+            if (p.edgeCatastropheSmooth)
+            {
+                pCat *= (1.0 - cosAngle);
+            }
+
+            // apply catastrophe
+            if (randomGen.rand() <= pCat)
+            {
+                tv.trajectory->conditionalRemove();
+                catastrophe();
+
+                // no wall crossing
+                return;
+            }
+        }
+    }
+
+    // update boundarty crossing count
+    boundaryCrossingCount++;
+
+#ifdef DBG_ASSERT
+    if (mti->segments.last()->endItr != plus.nextCollision)
+    {
+        cerr << "DBG/ASSERT: nextCollision does not match with endItr upon entering wall event.\n";
+    }
+#endif
+
+    // wall crossing
+    mti->segments.last()->endItr = mti->plus.nextCollision;
+
+    // create a new segment
+    mti->segments.create(*mti, tv);
+    mti->segments.last()->startItr = tv.dir == ::forward ? tv.trajectory->wallBegin() : tv.trajectory->wallEnd();
+
+    // switch trajectory
+    mti->plus.switchTrajectory(
+    tv.trajectory, tv.dir, tv.dir == ::forward ? tv.trajectory->wallBegin() : tv.trajectory->wallEnd());
+
+    if (mti->segments.size() == 2)
+    {
+        // MT with two segment of zero (=0) length, consider possibilty of a disappear event
+        mti->minus.determineEvent();
+        mti->setDisappearEvent();
+    }
 }


### PR DESCRIPTION
# Overview

This PR aims to refactor the last parts of the code base that depend on Boost. There are many advantages to that, as outlined in the [discussion](https://github.com/corticalsim/corticalsim3d-nlesc/discussions/43#discussion-10106651). 

NOTE: This branch contains work in progress and **does not compile yet**. 

# Changes

The most notable change is that the `DLList` class has been refactored to use only `STL` components. As a consequence, creating an item via `DLList::create()` returns an iterator rather than a pointer. This is necessary to streamline the process of adding and removing elements, but it requires further changes in other classes (see the individual commits below).

Some methods need to be moved into other classes to simplify the logic (e.g., moving `catastrophe()`, `rescue()` and `wall()` from `Microtubule` to `System`).