### PR TITLE
Fixed multimap type

### DIFF
--- a/include/corticalSimReal.h
+++ b/include/corticalSimReal.h
@@ -192,10 +192,7 @@ class Intersection;
 class OccupiedIntersection;
 #endif
 
-typedef multimap<double,
-                 Intersection,
-                 std::less<double>,
-                 boost::fast_pool_allocator<std::pair<double, Intersection>>>::iterator IntersectionItr;
+typedef multimap<double, Intersection>::iterator IntersectionItr;
 typedef int EventDescriptorIndex;
 typedef int EventTrackingTag;
 typedef list<Segment*>::iterator TrjSegmentTag;
@@ -423,8 +420,7 @@ class Trajectory: public DLBaseItem<Trajectory>
     // regular catastrophe value at the trajectory far end
     double nextTrpCat;
 
-    multimap<double, Intersection, std::less<double>, boost::fast_pool_allocator<std::pair<double, Intersection>>>
-    intersections;
+    multimap<double, Intersection> intersections;
 
     // sorted list of all intersections
     IntersectionItr wallEnd()


### PR DESCRIPTION
Changed the type of the `intersections` multimap and the declared multimap iterator type as GCC >=16 was raising an error.